### PR TITLE
feat(2022-12-13): updated the sdk as per the api spec released on 2022-12-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/IBM/vpc-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud VPC Go SDK Version 0.27.0
+# IBM Cloud VPC Go SDK Version 0.28.0
 Go client library to interact with the various [IBM Cloud VPC Services APIs](https://cloud.ibm.com/apidocs?category=vpc).
 
 **Note:** Given the current version of all VPC SDKs across supported languages and the current VPC API specification, we retracted the vpc-go-sdk version 1.x to version v0.6.0, which had the same features as v1.0.1.
-Consider using v0.27.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
+Consider using v0.28.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
 
 This SDK uses [Semantic Versioning](https://semver.org), and as such there may be backward-incompatible changes for any new `0.y.z` version.
 ## Table of Contents
@@ -64,7 +64,7 @@ Use this command to download and install the VPC Go SDK service to allow your Go
 use it:
 
 ```
-go get github.com/IBM/vpc-go-sdk@v0.27.0
+go get github.com/IBM/vpc-go-sdk@v0.28.0
 ```
 
 
@@ -90,7 +90,7 @@ to your `Gopkg.toml` file.  Here is an example:
 ```
 [[constraint]]
   name = "github.com/IBM/vpc-go-sdk/"
-  version = "0.27.0"
+  version = "0.28.0"
 ```
 
 Then run `dep ensure`.

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.27.0"
+const Version = "0.28.0"

--- a/vpcv1/vpc_v1.go
+++ b/vpcv1/vpc_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.55.1-b24c7487-20220831-201343
+ * IBM OpenAPI SDK Code Generator Version: 3.60.2-95dc7721-20221102-203229
  */
 
 // Package vpcv1 : Operations and models for the VpcV1 service
@@ -37,7 +37,7 @@ import (
 // VpcV1 : The IBM Cloud Virtual Private Cloud (VPC) API can be used to programmatically provision and manage virtual
 // server instances, along with subnets, volumes, load balancers, and more.
 //
-// API Version: 2022-09-13
+// API Version: 2022-12-13
 type VpcV1 struct {
 	Service *core.BaseService
 
@@ -580,7 +580,7 @@ func (vpc *VpcV1) GetVPCDefaultNetworkACLWithContext(ctx context.Context, getVPC
 
 // GetVPCDefaultRoutingTable : Retrieve a VPC's default routing table
 // This request retrieves the default routing table for the VPC specified by the identifier in the URL. The default
-// routing table is associated with any subnets in the VPC which have not been explicitly associated with a user-defined
+// routing table is associated with any subnets in the VPC which have not been explicitly associated with another
 // routing table.
 func (vpc *VpcV1) GetVPCDefaultRoutingTable(getVPCDefaultRoutingTableOptions *GetVPCDefaultRoutingTableOptions) (result *DefaultRoutingTable, response *core.DetailedResponse, err error) {
 	return vpc.GetVPCDefaultRoutingTableWithContext(context.Background(), getVPCDefaultRoutingTableOptions)
@@ -1052,12 +1052,15 @@ func (vpc *VpcV1) UpdateVPCAddressPrefixWithContext(ctx context.Context, updateV
 // This request lists all routes in the VPC's default routing table. Each route is zone-specific and directs any packets
 // matching its destination CIDR block to a `next_hop` IP address. The most specific route matching a packet's
 // destination will be used. If multiple equally-specific routes exist, traffic will be distributed across them.
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) ListVPCRoutes(listVPCRoutesOptions *ListVPCRoutesOptions) (result *RouteCollection, response *core.DetailedResponse, err error) {
 	return vpc.ListVPCRoutesWithContext(context.Background(), listVPCRoutesOptions)
 }
 
 // ListVPCRoutesWithContext is an alternate form of the ListVPCRoutes method which supports a Context parameter
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) ListVPCRoutesWithContext(ctx context.Context, listVPCRoutesOptions *ListVPCRoutesOptions) (result *RouteCollection, response *core.DetailedResponse, err error) {
+	core.GetLogger().Warn("A deprecated operation has been invoked: ListVPCRoutes")
 	err = core.ValidateNotNil(listVPCRoutesOptions, "listVPCRoutesOptions cannot be nil")
 	if err != nil {
 		return
@@ -1126,12 +1129,15 @@ func (vpc *VpcV1) ListVPCRoutesWithContext(ctx context.Context, listVPCRoutesOpt
 // This request creates a new route in the VPC's default routing table. The route prototype object is structured in the
 // same way as a retrieved route, and contains the information necessary to create the new route. The request will fail
 // if the new route will cause a loop.
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) CreateVPCRoute(createVPCRouteOptions *CreateVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return vpc.CreateVPCRouteWithContext(context.Background(), createVPCRouteOptions)
 }
 
 // CreateVPCRouteWithContext is an alternate form of the CreateVPCRoute method which supports a Context parameter
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) CreateVPCRouteWithContext(ctx context.Context, createVPCRouteOptions *CreateVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
+	core.GetLogger().Warn("A deprecated operation has been invoked: CreateVPCRoute")
 	err = core.ValidateNotNil(createVPCRouteOptions, "createVPCRouteOptions cannot be nil")
 	if err != nil {
 		return
@@ -1211,12 +1217,15 @@ func (vpc *VpcV1) CreateVPCRouteWithContext(ctx context.Context, createVPCRouteO
 
 // DeleteVPCRoute : Delete a VPC route
 // This request deletes a route. This operation cannot be reversed.
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) DeleteVPCRoute(deleteVPCRouteOptions *DeleteVPCRouteOptions) (response *core.DetailedResponse, err error) {
 	return vpc.DeleteVPCRouteWithContext(context.Background(), deleteVPCRouteOptions)
 }
 
 // DeleteVPCRouteWithContext is an alternate form of the DeleteVPCRoute method which supports a Context parameter
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) DeleteVPCRouteWithContext(ctx context.Context, deleteVPCRouteOptions *DeleteVPCRouteOptions) (response *core.DetailedResponse, err error) {
+	core.GetLogger().Warn("A deprecated operation has been invoked: DeleteVPCRoute")
 	err = core.ValidateNotNil(deleteVPCRouteOptions, "deleteVPCRouteOptions cannot be nil")
 	if err != nil {
 		return
@@ -1263,12 +1272,15 @@ func (vpc *VpcV1) DeleteVPCRouteWithContext(ctx context.Context, deleteVPCRouteO
 
 // GetVPCRoute : Retrieve a VPC route
 // This request retrieves a single route specified by the identifier in the URL.
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) GetVPCRoute(getVPCRouteOptions *GetVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return vpc.GetVPCRouteWithContext(context.Background(), getVPCRouteOptions)
 }
 
 // GetVPCRouteWithContext is an alternate form of the GetVPCRoute method which supports a Context parameter
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) GetVPCRouteWithContext(ctx context.Context, getVPCRouteOptions *GetVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
+	core.GetLogger().Warn("A deprecated operation has been invoked: GetVPCRoute")
 	err = core.ValidateNotNil(getVPCRouteOptions, "getVPCRouteOptions cannot be nil")
 	if err != nil {
 		return
@@ -1328,12 +1340,15 @@ func (vpc *VpcV1) GetVPCRouteWithContext(ctx context.Context, getVPCRouteOptions
 // UpdateVPCRoute : Update a VPC route
 // This request updates a route with the information in a provided route patch. The route patch object is structured in
 // the same way as a retrieved route and contains only the information to be updated.
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) UpdateVPCRoute(updateVPCRouteOptions *UpdateVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return vpc.UpdateVPCRouteWithContext(context.Background(), updateVPCRouteOptions)
 }
 
 // UpdateVPCRouteWithContext is an alternate form of the UpdateVPCRoute method which supports a Context parameter
+// Deprecated: this method is deprecated and may be removed in a future release.
 func (vpc *VpcV1) UpdateVPCRouteWithContext(ctx context.Context, updateVPCRouteOptions *UpdateVPCRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
+	core.GetLogger().Warn("A deprecated operation has been invoked: UpdateVPCRoute")
 	err = core.ValidateNotNil(updateVPCRouteOptions, "updateVPCRouteOptions cannot be nil")
 	if err != nil {
 		return
@@ -1397,10 +1412,10 @@ func (vpc *VpcV1) UpdateVPCRouteWithContext(ctx context.Context, updateVPCRouteO
 }
 
 // ListVPCRoutingTables : List all routing tables for a VPC
-// This request lists all user-defined routing tables for a VPC.  Each subnet in a VPC is associated with a routing
-// table, which controls delivery of packets sent on that subnet according to the action of the most specific matching
-// route in the table.  If multiple equally-specific routes exist, traffic will be distributed across them. If no routes
-// match, delivery will be controlled by the system's built-in routes.
+// This request lists all routing tables for a VPC. Each subnet in a VPC is associated with a routing table, which
+// controls delivery of packets sent on that subnet according to the action of the most specific matching route in the
+// table. If multiple equally-specific routes exist, traffic will be distributed across them. If no routes match,
+// delivery will be controlled by the system's built-in routes.
 func (vpc *VpcV1) ListVPCRoutingTables(listVPCRoutingTablesOptions *ListVPCRoutingTablesOptions) (result *RoutingTableCollection, response *core.DetailedResponse, err error) {
 	return vpc.ListVPCRoutingTablesWithContext(context.Background(), listVPCRoutingTablesOptions)
 }
@@ -1472,9 +1487,8 @@ func (vpc *VpcV1) ListVPCRoutingTablesWithContext(ctx context.Context, listVPCRo
 }
 
 // CreateVPCRoutingTable : Create a routing table for a VPC
-// This request creates a user-defined routing table from a routing table prototype object. The prototype object is
-// structured in the same way as a retrieved routing table, and contains the information necessary to create the new
-// routing table.
+// This request creates a routing table from a routing table prototype object. The prototype object is structured in the
+// same way as a retrieved routing table, and contains the information necessary to create the new routing table.
 func (vpc *VpcV1) CreateVPCRoutingTable(createVPCRoutingTableOptions *CreateVPCRoutingTableOptions) (result *RoutingTable, response *core.DetailedResponse, err error) {
 	return vpc.CreateVPCRoutingTableWithContext(context.Background(), createVPCRoutingTableOptions)
 }
@@ -14823,7 +14837,8 @@ func (vpc *VpcV1) ListSecurityGroupTargetsWithContext(ctx context.Context, listS
 // This request removes a target from a security group. For this request to succeed, the target must be attached to at
 // least one other security group.  The specified target identifier can be:
 //
-// - A network interface identifier
+// - An instance network interface identifier
+// - A bare metal server network interface identifier
 // - A VPN server identifier
 // - An application load balancer identifier
 // - An endpoint gateway identifier
@@ -14948,7 +14963,8 @@ func (vpc *VpcV1) GetSecurityGroupTargetWithContext(ctx context.Context, getSecu
 // CreateSecurityGroupTargetBinding : Add a target to a security group
 // This request adds a resource to an existing security group. The specified target identifier can be:
 //
-// - A network interface identifier
+// - An instance network interface identifier
+// - A bare metal server network interface identifier
 // - A VPN server identifier
 // - An application load balancer identifier
 // - An endpoint gateway identifier
@@ -21453,10 +21469,10 @@ type AddressPrefix struct {
 
 	// Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically
 	// created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected
-	// words, but may be updated with a user-specified name.
+	// words, but may be changed.
 	IsDefault *bool `json:"is_default" validate:"required"`
 
-	// The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+	// The name for this address prefix. The name must not be used by another address prefix for the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The zone this address prefix resides in.
@@ -21601,7 +21617,7 @@ type AddressPrefixPatch struct {
 	// Updating to false removes the default prefix for this zone in this VPC.
 	IsDefault *bool `json:"is_default,omitempty"`
 
-	// The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+	// The name for this address prefix. The name must not be used by another address prefix for the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -21664,7 +21680,7 @@ type BackupPolicy struct {
 	// be subject to the backup policy.
 	MatchUserTags []string `json:"match_user_tags" validate:"required"`
 
-	// The unique user-defined name for this backup policy.
+	// The name for this backup policy. The name is unique across all backup policies in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The plans for the backup policy.
@@ -21854,7 +21870,7 @@ type BackupPolicyPatch struct {
 	// tag and a matching type will be subject to the backup policy.
 	MatchUserTags []string `json:"match_user_tags,omitempty"`
 
-	// The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in.
+	// The name for this backup policy. The name must not be used by another backup policy in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -21915,7 +21931,7 @@ type BackupPolicyPlan struct {
 	// The lifecycle state of this backup policy plan.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The unique user-defined name for this backup policy plan.
+	// The name for this backup policy plan. The name is unique across all plans in the backup policy.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -22101,8 +22117,7 @@ type BackupPolicyPlanPatch struct {
 
 	DeletionTrigger *BackupPolicyPlanDeletionTriggerPatch `json:"deletion_trigger,omitempty"`
 
-	// The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides
-	// in.
+	// The name for this backup policy plan. The name must not be used by another plan for the backup policy.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -22167,8 +22182,8 @@ type BackupPolicyPlanPrototype struct {
 
 	DeletionTrigger *BackupPolicyPlanDeletionTriggerPrototype `json:"deletion_trigger,omitempty"`
 
-	// The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this backup policy plan. The name must not be used by another plan for the backup policy. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -22224,7 +22239,7 @@ type BackupPolicyPlanReference struct {
 	// The unique identifier for this backup policy plan.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this backup policy plan.
+	// The name for this backup policy plan. The name is unique across all plans in the backup policy.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -22316,7 +22331,7 @@ type BareMetalServer struct {
 	// The amount of memory, truncated to whole gibibytes.
 	Memory *int64 `json:"memory" validate:"required"`
 
-	// The user-defined name for this bare metal server (and default system hostname).
+	// The name for this bare metal server. The name is unique across all bare metal servers in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interfaces for this bare metal server, including the primary network interface.
@@ -22478,7 +22493,7 @@ type BareMetalServerBootTarget struct {
 	// The unique identifier for this bare metal server disk.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this disk.
+	// The name for this bare metal server disk. The name is unique across all disks on the bare metal server.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -22738,7 +22753,7 @@ type BareMetalServerDisk struct {
 	// unexpected property value was encountered.
 	InterfaceType *string `json:"interface_type" validate:"required"`
 
-	// The user-defined name for this disk.
+	// The name for this bare metal server disk. The name is unique across all disks on the bare metal server.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -22824,7 +22839,7 @@ func UnmarshalBareMetalServerDiskCollection(m map[string]json.RawMessage, result
 
 // BareMetalServerDiskPatch : BareMetalServerDiskPatch struct
 type BareMetalServerDiskPatch struct {
-	// The user-defined name for this disk.
+	// The name for this bare metal server disk. The name must not be used by another disk on the bare metal server.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -23057,7 +23072,7 @@ type BareMetalServerNetworkInterface struct {
 	// The MAC address of the interface.  If absent, the value is not known.
 	MacAddress *string `json:"mac_address" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interface port speed in Mbps.
@@ -23285,8 +23300,8 @@ type BareMetalServerNetworkInterfacePatch struct {
 	// This must be `true` when `interface_type` is `hipersocket`.
 	EnableInfrastructureNat *bool `json:"enable_infrastructure_nat,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -23364,8 +23379,8 @@ type BareMetalServerNetworkInterfacePrototype struct {
 	//   - Not supported on bare metal servers with a `cpu.architecture` of `s390x`.
 	InterfaceType *string `json:"interface_type" validate:"required"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using
@@ -23452,7 +23467,8 @@ func UnmarshalBareMetalServerNetworkInterfacePrototype(m map[string]json.RawMess
 
 // BareMetalServerPatch : BareMetalServerPatch struct
 type BareMetalServerPatch struct {
-	// The user-defined name for this bare metal server (and default system hostname).
+	// The name for this bare metal server. The name must not be used by another bare metal server in the region. Changing
+	// the name will not affect the system hostname.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -23511,8 +23527,8 @@ type BareMetalServerPrimaryNetworkInterfacePrototype struct {
 	//   - Not supported on bare metal servers with a `cpu.architecture` of `s390x`.
 	InterfaceType *string `json:"interface_type,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using
@@ -23623,7 +23639,7 @@ type BareMetalServerProfile struct {
 	// The resource type.
 	ResourceType *string `json:"resource_type" validate:"required"`
 
-	// The supported trusted platform module (TPM) modes for this bare metal server profile.
+	// The supported trusted platform module modes for this bare metal server profile.
 	SupportedTrustedPlatformModuleModes *BareMetalServerProfileSupportedTrustedPlatformModuleModes `json:"supported_trusted_platform_module_modes" validate:"required"`
 }
 
@@ -24499,12 +24515,12 @@ func UnmarshalBareMetalServerProfileReference(m map[string]json.RawMessage, resu
 	return
 }
 
-// BareMetalServerProfileSupportedTrustedPlatformModuleModes : The supported trusted platform module (TPM) modes for this bare metal server profile.
+// BareMetalServerProfileSupportedTrustedPlatformModuleModes : The supported trusted platform module modes for this bare metal server profile.
 type BareMetalServerProfileSupportedTrustedPlatformModuleModes struct {
 	// The type for this profile field.
 	Type *string `json:"type" validate:"required"`
 
-	// The supported trusted platform module (TPM) modes.
+	// The supported trusted platform module modes.
 	Values []string `json:"values" validate:"required"`
 }
 
@@ -24515,16 +24531,14 @@ const (
 )
 
 // Constants associated with the BareMetalServerProfileSupportedTrustedPlatformModuleModes.Values property.
-// The mode for the trusted platform module (TPM):
-// - `tpm_2`: Standard TPM 2 capabilities
-// - `tpm_2_with_txt`: Standard TPM 2 with Intel Trusted Execution Technology (TXT)
+// The trusted platform module (TPM) mode:
+// - `tpm_2`: TPM 2.0
 //
 // The enumerated values for this property are expected to expand in the future. When processing this property, check
 // for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the
 // unexpected property value was encountered.
 const (
-	BareMetalServerProfileSupportedTrustedPlatformModuleModesValuesTpm2Const        = "tpm_2"
-	BareMetalServerProfileSupportedTrustedPlatformModuleModesValuesTpm2WithTxtConst = "tpm_2_with_txt"
+	BareMetalServerProfileSupportedTrustedPlatformModuleModesValuesTpm2Const = "tpm_2"
 )
 
 // UnmarshalBareMetalServerProfileSupportedTrustedPlatformModuleModes unmarshals an instance of BareMetalServerProfileSupportedTrustedPlatformModuleModes from the specified map of raw messages.
@@ -24595,12 +24609,11 @@ func UnmarshalBareMetalServerStatusReason(m map[string]json.RawMessage, result i
 
 // BareMetalServerTrustedPlatformModule : BareMetalServerTrustedPlatformModule struct
 type BareMetalServerTrustedPlatformModule struct {
-	// Indicates whether the trusted platform module (TPM) is enabled. If enabled, `mode` will also be set.
+	// Indicates whether the trusted platform module is enabled.
 	Enabled *bool `json:"enabled" validate:"required"`
 
-	// The mode for the trusted platform module (TPM):
-	// - `tpm_2`: Standard TPM 2 capabilities
-	// - `tpm_2_with_txt`: Standard TPM 2 with Intel Trusted Execution Technology (TXT)
+	// The trusted platform module (TPM) mode:
+	// - `tpm_2`: TPM 2.0
 	//
 	// The enumerated values for this property are expected to expand in the future. When processing this property, check
 	// for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the
@@ -24609,16 +24622,14 @@ type BareMetalServerTrustedPlatformModule struct {
 }
 
 // Constants associated with the BareMetalServerTrustedPlatformModule.Mode property.
-// The mode for the trusted platform module (TPM):
-// - `tpm_2`: Standard TPM 2 capabilities
-// - `tpm_2_with_txt`: Standard TPM 2 with Intel Trusted Execution Technology (TXT)
+// The trusted platform module (TPM) mode:
+// - `tpm_2`: TPM 2.0
 //
 // The enumerated values for this property are expected to expand in the future. When processing this property, check
 // for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the
 // unexpected property value was encountered.
 const (
-	BareMetalServerTrustedPlatformModuleModeTpm2Const        = "tpm_2"
-	BareMetalServerTrustedPlatformModuleModeTpm2WithTxtConst = "tpm_2_with_txt"
+	BareMetalServerTrustedPlatformModuleModeTpm2Const = "tpm_2"
 )
 
 // UnmarshalBareMetalServerTrustedPlatformModule unmarshals an instance of BareMetalServerTrustedPlatformModule from the specified map of raw messages.
@@ -24882,8 +24893,8 @@ type CreateBackupPolicyOptions struct {
 	// be subject to the backup policy.
 	MatchUserTags []string `json:"match_user_tags,omitempty"`
 
-	// The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in.
-	// If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this backup policy. The name must not be used by another backup policy in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The prototype objects for backup plans to be created for this backup policy.
@@ -24967,8 +24978,8 @@ type CreateBackupPolicyPlanOptions struct {
 
 	DeletionTrigger *BackupPolicyPlanDeletionTriggerPrototype `json:"deletion_trigger,omitempty"`
 
-	// The user-defined name for this backup policy plan. Names must be unique within the backup policy this plan resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this backup policy plan. The name must not be used by another plan for the backup policy. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -25142,8 +25153,10 @@ type CreateBareMetalServerOptions struct {
 	// The zone this bare metal server will reside in.
 	Zone ZoneIdentityIntf `json:"zone" validate:"required"`
 
-	// The unique user-defined name for this bare metal server (and default system hostname). If unspecified, the name will
-	// be a hyphenated list of randomly-selected words.
+	// The name for this bare metal server. The name must not be used by another bare metal server in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the bare metal server.
@@ -25235,8 +25248,8 @@ type CreateDedicatedHostGroupOptions struct {
 	// The dedicated host profile family for hosts in this group.
 	Family *string `json:"family,omitempty"`
 
-	// The unique user-defined name for this dedicated host group. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this dedicated host group. The name must not be used by another dedicated host group in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -25339,8 +25352,8 @@ type CreateEndpointGatewayOptions struct {
 	// The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 	Ips []EndpointGatewayReservedIPIntf `json:"ips,omitempty"`
 
-	// The user-defined name for this endpoint gateway. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words. Names must be unique within the VPC this endpoint gateway is serving.
+	// The name for this endpoint gateway. The name must not be used by another endpoint gateway in the VPC. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -25448,8 +25461,8 @@ type CreateFlowLogCollectorOptions struct {
 	// Indicates whether this collector will be active upon creation.
 	Active *bool `json:"active,omitempty"`
 
-	// The unique user-defined name for this flow log collector. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this flow log collector. The name must not be used by another flow log collector in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -25527,7 +25540,8 @@ type CreateIkePolicyOptions struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime,omitempty"`
 
-	// The user-defined name for this IKE policy.
+	// The name for this IKE policy. The name must not be used by another IKE policies in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -25907,10 +25921,8 @@ type CreateInstanceGroupOptions struct {
 	// This property must be specified if and only if `load_balancer_pool` has been specified.
 	ApplicationPort *int64 `json:"application_port,omitempty"`
 
-	// The load balancer associated with `load_balancer_pool`.
-	//
-	// This property must be specified if and only if `load_balancer_pool` has been
-	// specified.
+	// The load balancer associated with the specified load balancer pool.
+	// Required if `load_balancer_pool` is specified.
 	//
 	// At present, only load balancers in the `application` family are supported.
 	LoadBalancer LoadBalancerIdentityIntf `json:"load_balancer,omitempty"`
@@ -25924,8 +25936,8 @@ type CreateInstanceGroupOptions struct {
 	// The number of instances in the instance group.
 	MembershipCount *int64 `json:"membership_count,omitempty"`
 
-	// The unique user-defined name for this instance group. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this instance group. The name must not be used by another instance group in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -26010,8 +26022,8 @@ type CreateInstanceNetworkInterfaceOptions struct {
 	// interface. If true, source IP spoofing is allowed on this interface.
 	AllowIPSpoofing *bool `json:"allow_ip_spoofing,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for network interface. The name must not be used by another network interface on the virtual server
+	// instance. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using
@@ -26143,11 +26155,11 @@ type CreateInstanceVolumeAttachmentOptions struct {
 	// An existing volume to attach to the instance, or a prototype object for a new volume.
 	Volume VolumeAttachmentPrototypeVolumeIntf `json:"volume" validate:"required"`
 
-	// If set to true, when deleting the instance the volume will also be deleted.
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
 
-	// The user-defined name for this volume attachment. Names must be unique within the instance the volume attachment
-	// resides in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this volume attachment. The name must not be used by another volume attachment on the instance. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -26219,7 +26231,8 @@ type CreateIpsecPolicyOptions struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime,omitempty"`
 
-	// The user-defined name for this IPsec policy.
+	// The name for this IPsec policy. The name must not be used by another IPsec policies in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -26344,8 +26357,8 @@ type CreateKeyOptions struct {
 	// imported.
 	PublicKey *string `json:"public_key" validate:"required"`
 
-	// The unique user-defined name for this key. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words.
+	// The name for this key. The name must not be used by another key in the region. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -26449,7 +26462,8 @@ type CreateLoadBalancerListenerOptions struct {
 	// `protocol` of `http`, and the target listener must have a `protocol` of `https`.
 	HTTPSRedirect *LoadBalancerListenerHTTPSRedirectPrototype `json:"https_redirect,omitempty"`
 
-	// The policy prototype objects for this listener.
+	// The policy prototype objects for this listener. The load balancer must be in the
+	// `application` family.
 	Policies []LoadBalancerListenerPolicyPrototype `json:"policies,omitempty"`
 
 	// The listener port number, or the inclusive lower bound of the port range. Each listener in the load balancer must
@@ -26599,7 +26613,8 @@ type CreateLoadBalancerListenerPolicyOptions struct {
 	// Priority of the policy. Lower value indicates higher priority.
 	Priority *int64 `json:"priority" validate:"required"`
 
-	// The user-defined name for this policy. Names must be unique within the load balancer listener the policy resides in.
+	// The name for this policy. The name must not be used by another policy for the load balancer listener. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The rule prototype objects for this policy.
@@ -26827,8 +26842,8 @@ type CreateLoadBalancerOptions struct {
 	// To activate logging, the load balancer profile must support the specified logging type.
 	Logging *LoadBalancerLogging `json:"logging,omitempty"`
 
-	// The user-defined name for this load balancer. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this load balancer. The name must not be used by another load balancer in the VPC.  If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The pools of this load balancer.
@@ -27029,8 +27044,8 @@ type CreateLoadBalancerPoolOptions struct {
 	// tuple cannot be shared by a pool member of any other load balancer in the same VPC.
 	Members []LoadBalancerPoolMemberPrototype `json:"members,omitempty"`
 
-	// The user-defined name for this load balancer pool. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this load balancer pool. The name must not be used by another pool for the load balancer. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The PROXY protocol setting for this pool:
@@ -27219,8 +27234,8 @@ type CreatePlacementGroupOptions struct {
 	// unexpected strategy was encountered.
 	Strategy *string `json:"strategy" validate:"required"`
 
-	// The unique user-defined name for this placement group. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this placement group. The name must not be used by another placement group in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -27285,8 +27300,8 @@ type CreatePublicGatewayOptions struct {
 
 	FloatingIP PublicGatewayFloatingIPPrototypeIntf `json:"floating_ip,omitempty"`
 
-	// The user-defined name for this public gateway. Names must be unique within the VPC the public gateway resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this public gateway. The name must not be used by another public gateway in the VPC. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -27346,8 +27361,8 @@ type CreateSecurityGroupOptions struct {
 	// The VPC this security group will reside in.
 	VPC VPCIdentityIntf `json:"vpc" validate:"required"`
 
-	// The user-defined name for this security group. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name must not be used by another security group for the VPC. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -27545,9 +27560,9 @@ type CreateSubnetReservedIPOptions struct {
 	// `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the subnet the reserved IP resides in. Names beginning with `ibm-` are reserved
-	// for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated
+	// list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The target to bind this reserved IP to.  The target must be in the same VPC.
@@ -27657,8 +27672,8 @@ type CreateVPCAddressPrefixOptions struct {
 	// have a default address prefix for this zone.
 	IsDefault *bool `json:"is_default,omitempty"`
 
-	// The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this address prefix. The name must not be used by another address prefix for the VPC. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -27712,8 +27727,9 @@ func (options *CreateVPCAddressPrefixOptions) SetHeaders(param map[string]string
 
 // CreateVPCOptions : The CreateVPC options.
 type CreateVPCOptions struct {
-	// Indicates whether a default address prefix will be automatically created for each zone in this VPC. If `manual`,
-	// this VPC will be created with no default address prefixes.
+	// Indicates whether a [default address prefix](https://cloud.ibm.com/docs/vpc?topic=vpc-configuring-address-prefixes)
+	// will be automatically created for each zone in this VPC. If `manual`, this VPC will be created with no default
+	// address prefixes.
 	//
 	// Since address prefixes are managed identically regardless of whether they were automatically created, the value is
 	// not preserved as a VPC property.
@@ -27724,8 +27740,8 @@ type CreateVPCOptions struct {
 	// connected in this way. This value is set at creation and subsequently immutable.
 	ClassicAccess *bool `json:"classic_access,omitempty"`
 
-	// The unique user-defined name for this VPC. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words.
+	// The name for this VPC. The name must not be used by another VPC in the region. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -27737,8 +27753,9 @@ type CreateVPCOptions struct {
 }
 
 // Constants associated with the CreateVPCOptions.AddressPrefixManagement property.
-// Indicates whether a default address prefix will be automatically created for each zone in this VPC. If `manual`, this
-// VPC will be created with no default address prefixes.
+// Indicates whether a [default address prefix](https://cloud.ibm.com/docs/vpc?topic=vpc-configuring-address-prefixes)
+// will be automatically created for each zone in this VPC. If `manual`, this VPC will be created with no default
+// address prefixes.
 //
 // Since address prefixes are managed identically regardless of whether they were automatically created, the value is
 // not preserved as a VPC property.
@@ -27802,8 +27819,9 @@ type CreateVPCRouteOptions struct {
 	// - `drop`: drop the packet.
 	Action *string `json:"action,omitempty"`
 
-	// The user-defined name for this route. If unspecified, the name will be a hyphenated list of randomly-selected words.
-	// Names must be unique within the VPC routing table the route resides in.
+	// The name for this route. The name must not be used by another route in the routing table. Names starting with `ibm-`
+	// are reserved for system-provided routes, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// If `action` is `deliver`, the next hop that packets will be delivered to. For other `action`
@@ -27889,8 +27907,8 @@ type CreateVPCRoutingTableOptions struct {
 	// support is expected to expand in the future.
 	AcceptRoutesFrom []ResourceFilter `json:"accept_routes_from,omitempty"`
 
-	// The user-defined name for this routing table. Names must be unique within the VPC the routing table resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this routing table. The name must not be used by another routing table in the VPC. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// If set to `true`, this routing table will be used to route traffic that originates from [Direct
@@ -28030,8 +28048,9 @@ type CreateVPCRoutingTableRouteOptions struct {
 	// - `drop`: drop the packet.
 	Action *string `json:"action,omitempty"`
 
-	// The user-defined name for this route. If unspecified, the name will be a hyphenated list of randomly-selected words.
-	// Names must be unique within the VPC routing table the route resides in.
+	// The name for this route. The name must not be used by another route in the routing table. Names starting with `ibm-`
+	// are reserved for system-provided routes, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// If `action` is `deliver`, the next hop that packets will be delivered to. For other `action`
@@ -28214,8 +28233,8 @@ type CreateVPNServerOptions struct {
 	// Indicates whether the split tunneling is enabled on this VPN server.
 	EnableSplitTunneling *bool `json:"enable_split_tunneling,omitempty"`
 
-	// The user-defined name for this VPN server. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the VPC this VPN server is serving.
+	// The name for this VPN server. The name must not be used by another VPN server in the VPC. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The port number to use for this VPN server.
@@ -28350,8 +28369,8 @@ type CreateVPNServerRouteOptions struct {
 	// unexpected property value was encountered.
 	Action *string `json:"action,omitempty"`
 
-	// The user-defined name for this VPN route. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the VPN server the VPN route resides in.
+	// The name for this VPN server route. The name must not be used by another route for the VPN server. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -28450,7 +28469,7 @@ type DedicatedHost struct {
 	// The total amount of memory in gibibytes for this host.
 	Memory *int64 `json:"memory" validate:"required"`
 
-	// The unique user-defined name for this dedicated host.
+	// The name for this dedicated host. The name is unique across all dedicated hosts in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-dh-profiles) for this
@@ -28731,7 +28750,7 @@ type DedicatedHostDisk struct {
 	// The lifecycle state of this dedicated host disk.
 	LifecycleState *string `json:"lifecycle_state,omitempty"`
 
-	// The user-defined or system-provided name for this disk.
+	// The name for this dedicated host disk. The name is unique across all disks on the dedicated host.
 	Name *string `json:"name" validate:"required"`
 
 	// Indicates whether this dedicated host disk is available for instance disk creation.
@@ -28860,7 +28879,7 @@ func UnmarshalDedicatedHostDiskCollection(m map[string]json.RawMessage, result i
 
 // DedicatedHostDiskPatch : DedicatedHostDiskPatch struct
 type DedicatedHostDiskPatch struct {
-	// The user-defined name for this disk.
+	// The name for this dedicated host disk. The name must not be used by another disk on the dedicated host.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -28908,7 +28927,7 @@ type DedicatedHostGroup struct {
 	// The unique identifier for this dedicated host group.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name is unique across all dedicated host groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this dedicated host group.
@@ -29130,7 +29149,7 @@ func UnmarshalDedicatedHostGroupIdentity(m map[string]json.RawMessage, result in
 
 // DedicatedHostGroupPatch : DedicatedHostGroupPatch struct
 type DedicatedHostGroupPatch struct {
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name must not be used by another dedicated host group in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -29157,7 +29176,8 @@ func (dedicatedHostGroupPatch *DedicatedHostGroupPatch) AsPatch() (_patch map[st
 
 // DedicatedHostGroupPrototypeDedicatedHostByZoneContext : DedicatedHostGroupPrototypeDedicatedHostByZoneContext struct
 type DedicatedHostGroupPrototypeDedicatedHostByZoneContext struct {
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name must not be used by another dedicated host group in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the host's resource group is used.
@@ -29194,7 +29214,7 @@ type DedicatedHostGroupReference struct {
 	// The unique identifier for this dedicated host group.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name is unique across all dedicated host groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -29261,7 +29281,7 @@ type DedicatedHostPatch struct {
 	// If set to true, instances can be placed on this dedicated host.
 	InstancePlacementEnabled *bool `json:"instance_placement_enabled,omitempty"`
 
-	// The unique user-defined name for this dedicated host.
+	// The name for this dedicated host. The name must not be used by another dedicated host in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -29986,8 +30006,8 @@ type DedicatedHostPrototype struct {
 	// If set to true, instances can be placed on this dedicated host.
 	InstancePlacementEnabled *bool `json:"instance_placement_enabled,omitempty"`
 
-	// The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this dedicated host. The name must not be used by another dedicated host in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-dh-profiles) to use for this
@@ -30059,7 +30079,7 @@ type DedicatedHostReference struct {
 	// The unique identifier for this dedicated host.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this dedicated host.
+	// The name for this dedicated host. The name is unique across all dedicated hosts in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -30136,7 +30156,7 @@ type DefaultNetworkACL struct {
 	ID *string `json:"id" validate:"required"`
 
 	// The name of the default network ACL created for a VPC. The name will be a hyphenated list of randomly-selected words
-	// at creation, but may be user-specified with a subsequent request.
+	// at creation, but may be changed.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for the default network ACL for a VPC. Set to the VPC's
@@ -30221,7 +30241,7 @@ type DefaultRoutingTable struct {
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
 	// The name of the default routing table created for this VPC. The name will be a hyphenated list of randomly-selected
-	// words at creation, but may be user-specified with a subsequent request.
+	// words at creation, but may be changed.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -30368,8 +30388,8 @@ type DefaultSecurityGroup struct {
 	// The unique identifier for this security group.
 	ID *string `json:"id" validate:"required"`
 
-	// The name of the default security group created for a VPC. The name will be a hyphenated list of randomly-selected
-	// words at creation, but may be user-specified with a subsequent request.
+	// The name for the default security group for a VPC. The name will be a hyphenated list of randomly-selected words at
+	// creation, but may changed.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this security group.
@@ -32374,7 +32394,7 @@ type EndpointGateway struct {
 	// The lifecycle state of the endpoint gateway.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The unique user-defined name for this endpoint gateway.
+	// The name for this endpoint gateway. The name is unique across all endpoint gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this endpoint gateway.
@@ -32387,6 +32407,7 @@ type EndpointGateway struct {
 	SecurityGroups []SecurityGroupReference `json:"security_groups" validate:"required"`
 
 	// The fully qualified domain name for the target service.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	ServiceEndpoint *string `json:"service_endpoint,omitempty"`
 
 	// The fully qualified domain names for the target service.
@@ -32593,8 +32614,7 @@ func UnmarshalEndpointGatewayCollectionNext(m map[string]json.RawMessage, result
 
 // EndpointGatewayPatch : EndpointGatewayPatch struct
 type EndpointGatewayPatch struct {
-	// The user-defined name for this endpoint gateway. Names must be unique within the VPC this endpoint gateway is
-	// serving.
+	// The name for this endpoint gateway. The name must not be used by another endpoint gateway in the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -32659,9 +32679,9 @@ type EndpointGatewayReservedIP struct {
 	// `target` is deleted, or the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the subnet the reserved IP resides in. Names beginning with `ibm-` are reserved
-	// for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated
+	// list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The subnet in which to create this reserved IP.
@@ -32827,7 +32847,7 @@ type FloatingIP struct {
 	// The unique identifier for this floating IP.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this floating IP.
+	// The name for this floating IP. The name is unique across all floating IPs in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this floating IP.
@@ -33028,7 +33048,7 @@ func UnmarshalFloatingIPCollectionNext(m map[string]json.RawMessage, result inte
 
 // FloatingIPPatch : FloatingIPPatch struct
 type FloatingIPPatch struct {
-	// The unique user-defined name for this floating IP.
+	// The name for this floating IP. The name must not be used by another floating IP in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The network interface to bind the floating IP to, replacing any existing binding.
@@ -33066,8 +33086,8 @@ func (floatingIPPatch *FloatingIPPatch) AsPatch() (_patch map[string]interface{}
 // - FloatingIPPrototypeFloatingIPByZone
 // - FloatingIPPrototypeFloatingIPByTarget
 type FloatingIPPrototype struct {
-	// The unique user-defined name for this floating IP. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this floating IP. The name must not be used by another floating IP in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -33130,7 +33150,7 @@ type FloatingIPReference struct {
 	// The unique identifier for this floating IP.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this floating IP.
+	// The name for this floating IP. The name is unique across all floating IPs in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -33198,7 +33218,7 @@ type FloatingIPTarget struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name,omitempty"`
 
 	PrimaryIP *ReservedIPReference `json:"primary_ip,omitempty"`
@@ -33336,7 +33356,7 @@ type FlowLogCollector struct {
 	// The lifecycle state of the flow log collector.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The unique user-defined name for this flow log collector.
+	// The name for this flow log collector. The name is unique across all flow log collectors in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this flow log collector.
@@ -33528,7 +33548,7 @@ type FlowLogCollectorPatch struct {
 	// activates the collector.
 	Active *bool `json:"active,omitempty"`
 
-	// The unique user-defined name for this flow log collector.
+	// The name for this flow log collector. The name must not be used by another flow log collector in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -33585,7 +33605,7 @@ type FlowLogCollectorTarget struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -36279,7 +36299,7 @@ type IkePolicy struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime" validate:"required"`
 
-	// The user-defined name for this IKE policy.
+	// The name for this IKE policy. The name is unique across all IKE policies in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The IKE negotiation mode. Only `main` is supported.
@@ -36467,7 +36487,7 @@ type IkePolicyPatch struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime,omitempty"`
 
-	// The user-defined name for this IKE policy.
+	// The name for this IKE policy. The name must not be used by another IKE policy in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -36547,7 +36567,7 @@ type IkePolicyReference struct {
 	// The unique identifier for this IKE policy.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this IKE policy.
+	// The name for this IKE policy. The name is unique across all IKE policies in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -36654,7 +36674,7 @@ type IPsecPolicy struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime" validate:"required"`
 
-	// The user-defined name for this IPsec policy.
+	// The name for this IPsec policy. The name is unique across all IPsec policies in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// Perfect Forward Secrecy
@@ -36919,7 +36939,7 @@ type IPsecPolicyPatch struct {
 	// The key lifetime in seconds.
 	KeyLifetime *int64 `json:"key_lifetime,omitempty"`
 
-	// The user-defined name for this IPsec policy.
+	// The name for this IPsec policy. The name must not be used by another IPsec policy in the region.
 	Name *string `json:"name,omitempty"`
 
 	// Perfect Forward Secrecy
@@ -37033,7 +37053,7 @@ type IPsecPolicyReference struct {
 	// The unique identifier for this IPsec policy.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this IPsec policy.
+	// The name for this IPsec policy. The name is unique across all IPsec policies in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -37176,7 +37196,7 @@ type Image struct {
 	// This property may be absent if the image has a `status` of `pending` or `failed`.
 	MinimumProvisionedSize *int64 `json:"minimum_provisioned_size,omitempty"`
 
-	// The user-defined or system-provided name for this image.
+	// The name for this image. The name is unique across all images in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The operating system included in this image.
@@ -37570,7 +37590,8 @@ func UnmarshalImageIdentity(m map[string]json.RawMessage, result interface{}) (e
 
 // ImagePatch : ImagePatch struct
 type ImagePatch struct {
-	// The unique user-defined name for this image. Names starting with `ibm-` are not allowed.
+	// The name for this image. The name must not be used by another image in the region. Names starting with `ibm-` are
+	// reserved for system-provided images, and are not allowed.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -37600,8 +37621,9 @@ func (imagePatch *ImagePatch) AsPatch() (_patch map[string]interface{}, err erro
 // - ImagePrototypeImageByFile
 // - ImagePrototypeImageBySourceVolume
 type ImagePrototype struct {
-	// The unique user-defined name for this image. Names starting with `ibm-` are not allowed. If unspecified, the name
-	// will be a hyphenated list of randomly-selected words.
+	// The name for this image. The name must not be used by another image in the region. Names starting with `ibm-` are
+	// reserved for system-provided images, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -37700,7 +37722,7 @@ type ImageReference struct {
 	// The unique identifier for this image.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined or system-provided name for this image.
+	// The name for this image. The name is unique across all images in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -37848,7 +37870,7 @@ type Instance struct {
 	// The metadata service configuration.
 	MetadataService *InstanceMetadataService `json:"metadata_service" validate:"required"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name is unique across all virtual server instances in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interfaces for this virtual server instance, including the primary network interface.
@@ -38081,6 +38103,7 @@ func UnmarshalInstance(m map[string]json.RawMessage, result interface{}) (err er
 // InstanceAction : InstanceAction struct
 type InstanceAction struct {
 	// The date and time that the action was completed.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	CompletedAt *strfmt.DateTime `json:"completed_at,omitempty"`
 
 	// The date and time that the action was created.
@@ -38090,15 +38113,19 @@ type InstanceAction struct {
 	Force *bool `json:"force,omitempty"`
 
 	// The URL for this instance action.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	Href *string `json:"href" validate:"required"`
 
 	// The identifier for this instance action.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	ID *string `json:"id" validate:"required"`
 
 	// The date and time that the action was started.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	StartedAt *strfmt.DateTime `json:"started_at,omitempty"`
 
 	// The current status of this action.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	Status *string `json:"status" validate:"required"`
 
 	// The type of action.
@@ -38540,7 +38567,7 @@ type InstanceDisk struct {
 	// unexpected property value was encountered.
 	InterfaceType *string `json:"interface_type" validate:"required"`
 
-	// The user-defined name for this disk.
+	// The name for this instance disk. The name is unique across all disks on the instance.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -38621,7 +38648,7 @@ func UnmarshalInstanceDiskCollection(m map[string]json.RawMessage, result interf
 
 // InstanceDiskPatch : InstanceDiskPatch struct
 type InstanceDiskPatch struct {
-	// The user-defined name for this disk.
+	// The name for this instance disk. The name must not be used by another disk on the instance.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -38658,7 +38685,7 @@ type InstanceDiskReference struct {
 	// The unique identifier for this instance disk.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this disk.
+	// The name for this instance disk. The name is unique across all disks on the instance.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -38786,7 +38813,7 @@ type InstanceGroup struct {
 	// The number of instances in the instance group.
 	MembershipCount *int64 `json:"membership_count" validate:"required"`
 
-	// The user-defined name for this instance group.
+	// The name for this instance group. The name is unique across all instance groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	ResourceGroup *ResourceGroupReference `json:"resource_group" validate:"required"`
@@ -38999,7 +39026,7 @@ type InstanceGroupManager struct {
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled" validate:"required"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name" validate:"required"`
 
 	// The date and time that the instance group manager was updated.
@@ -39123,7 +39150,8 @@ type InstanceGroupManagerAction struct {
 	// The unique identifier for this instance group manager action.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name is unique across all actions for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -39312,7 +39340,8 @@ type InstanceGroupManagerActionPatch struct {
 
 	Manager *InstanceGroupManagerActionManagerPatch `json:"manager,omitempty"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
+	// manager.
 	Name *string `json:"name,omitempty"`
 
 	// The date and time the scheduled action will run.
@@ -39360,7 +39389,7 @@ func (instanceGroupManagerActionPatch *InstanceGroupManagerActionPatch) AsPatch(
 // Models which "extend" this model:
 // - InstanceGroupManagerActionPrototypeScheduledActionPrototype
 type InstanceGroupManagerActionPrototype struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -39423,7 +39452,8 @@ type InstanceGroupManagerActionReference struct {
 	// The unique identifier for this instance group manager action.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name is unique across all actions for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -39682,7 +39712,7 @@ type InstanceGroupManagerPatch struct {
 	// The minimum number of members in a managed instance group.
 	MinMembershipCount *int64 `json:"min_membership_count,omitempty"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name must not be used by another manager for the instance group.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -39740,7 +39770,8 @@ type InstanceGroupManagerPolicy struct {
 	// The unique identifier for this instance group manager policy.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager policy.
+	// The name for this instance group manager policy. The name is unique across all policies for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The date and time that the instance group manager policy was updated.
@@ -39918,7 +39949,8 @@ type InstanceGroupManagerPolicyPatch struct {
 	// The metric value to be evaluated.
 	MetricValue *int64 `json:"metric_value,omitempty"`
 
-	// The user-defined name for this instance group manager policy.
+	// The name for this instance group manager policy. The name must not be used by another policy for the instance group
+	// manager.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -39964,7 +39996,7 @@ func (instanceGroupManagerPolicyPatch *InstanceGroupManagerPolicyPatch) AsPatch(
 // Models which "extend" this model:
 // - InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype
 type InstanceGroupManagerPolicyPrototype struct {
-	// The user-defined name for this instance group manager policy. Names must be unique within the instance group
+	// The name for this instance group manager policy. The name must not be used by another policy for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -40036,7 +40068,8 @@ type InstanceGroupManagerPolicyReference struct {
 	// The unique identifier for this instance group manager policy.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager policy.
+	// The name for this instance group manager policy. The name is unique across all policies for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -40089,7 +40122,7 @@ type InstanceGroupManagerPrototype struct {
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled,omitempty"`
 
-	// The user-defined name for this instance group manager. Names must be unique within the instance group. If
+	// The name for this instance group manager. The name must not be used by another manager for the instance group. If
 	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -40170,7 +40203,7 @@ type InstanceGroupManagerReference struct {
 	// The unique identifier for this instance group manager.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -40272,7 +40305,7 @@ type InstanceGroupManagerScheduledActionManager struct {
 	// The unique identifier for this instance group manager.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name,omitempty"`
 
 	// The desired maximum number of instance group members at the scheduled time.
@@ -40387,7 +40420,7 @@ type InstanceGroupMembership struct {
 
 	InstanceTemplate *InstanceTemplateReference `json:"instance_template" validate:"required"`
 
-	// The user-defined name for this instance group membership. Names must be unique within the instance group.
+	// The name for this instance group membership. The name is unique across all memberships for the instance group.
 	Name *string `json:"name" validate:"required"`
 
 	PoolMember *LoadBalancerPoolMemberReference `json:"pool_member,omitempty"`
@@ -40560,7 +40593,8 @@ func UnmarshalInstanceGroupMembershipCollectionNext(m map[string]json.RawMessage
 
 // InstanceGroupMembershipPatch : InstanceGroupMembershipPatch struct
 type InstanceGroupMembershipPatch struct {
-	// The user-defined name for this instance group membership. Names must be unique within the instance group.
+	// The name for this instance group membership. The name must not be used by another membership for the instance group
+	// manager.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -40598,10 +40632,8 @@ type InstanceGroupPatch struct {
 	// `default_trusted_profile.auto_link`.
 	InstanceTemplate InstanceTemplateIdentityIntf `json:"instance_template,omitempty"`
 
-	// The load balancer associated with `load_balancer_pool`.
-	//
-	// This property must be specified if and only if `load_balancer_pool` has been
-	// specified.
+	// The load balancer associated with the specified load balancer pool.
+	// Required if `load_balancer_pool` is specified.
 	//
 	// At present, only load balancers in the `application` family are supported.
 	LoadBalancer LoadBalancerIdentityIntf `json:"load_balancer,omitempty"`
@@ -40615,7 +40647,7 @@ type InstanceGroupPatch struct {
 	// The number of instances in the instance group.
 	MembershipCount *int64 `json:"membership_count,omitempty"`
 
-	// The user-defined name for this instance group.
+	// The name for this instance group. The name must not be used by another instance group in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The subnets to use when creating new instances.
@@ -40682,7 +40714,7 @@ type InstanceGroupReference struct {
 	// The unique identifier for this instance group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group.
+	// The name for this instance group. The name is unique across all instance groups in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -40871,7 +40903,8 @@ type InstancePatch struct {
 	// The metadata service configuration.
 	MetadataService *InstanceMetadataServicePatch `json:"metadata_service,omitempty"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. Changing the name will not affect the system hostname.
 	Name *string `json:"name,omitempty"`
 
 	// The placement restrictions to use for the virtual server instance. For the placement
@@ -41000,7 +41033,7 @@ type InstancePlacementTarget struct {
 	// The unique identifier for this dedicated host group.
 	ID *string `json:"id,omitempty"`
 
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name is unique across all dedicated host groups in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -41145,7 +41178,7 @@ type InstanceProfile struct {
 	Disks []InstanceProfileDisk `json:"disks" validate:"required"`
 
 	// The product family this virtual server instance profile belongs to.
-	Family *string `json:"family,omitempty"`
+	Family *string `json:"family" validate:"required"`
 
 	GpuCount InstanceProfileGpuIntf `json:"gpu_count,omitempty"`
 
@@ -42242,8 +42275,10 @@ type InstancePrototype struct {
 	// The metadata service configuration.
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -42273,7 +42308,7 @@ type InstancePrototype struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.
 	//
@@ -42362,7 +42397,7 @@ func UnmarshalInstancePrototype(m map[string]json.RawMessage, result interface{}
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -42413,7 +42448,7 @@ type InstanceReference struct {
 	// The unique identifier for this virtual server instance.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name is unique across all virtual server instances in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -42554,7 +42589,7 @@ type InstanceTemplate struct {
 	// The metadata service configuration.
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name is unique across all instance templates in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -42583,7 +42618,7 @@ type InstanceTemplate struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.
 	//
@@ -42685,7 +42720,7 @@ func UnmarshalInstanceTemplate(m map[string]json.RawMessage, result interface{})
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -42842,7 +42877,7 @@ func UnmarshalInstanceTemplateIdentity(m map[string]json.RawMessage, result inte
 
 // InstanceTemplatePatch : InstanceTemplatePatch struct
 type InstanceTemplatePatch struct {
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name must not be used by another instance template in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -42902,8 +42937,8 @@ type InstanceTemplatePrototype struct {
 	// The metadata service configuration.
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this instance template. The name must not be used by another instance template in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -42933,7 +42968,7 @@ type InstanceTemplatePrototype struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.
 	//
@@ -43023,7 +43058,7 @@ func UnmarshalInstanceTemplatePrototype(m map[string]json.RawMessage, result int
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -43074,7 +43109,7 @@ type InstanceTemplateReference struct {
 	// The unique identifier for this instance template.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name is unique across all instance templates in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -43168,8 +43203,8 @@ type Key struct {
 	// The length of this key (in bits).
 	Length *int64 `json:"length" validate:"required"`
 
-	// The unique user-defined name for this key. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words.
+	// The name for this key. The name must not be used by another key in the region. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name" validate:"required"`
 
 	// The public SSH key, consisting of two space-separated fields: the algorithm name, and the base64-encoded key.
@@ -43381,7 +43416,7 @@ func UnmarshalKeyIdentity(m map[string]json.RawMessage, result interface{}) (err
 
 // KeyPatch : KeyPatch struct
 type KeyPatch struct {
-	// The user-defined name for this key.
+	// The name for this key. The name must not be used by another key in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -43425,7 +43460,7 @@ type KeyReference struct {
 	// The unique identifier for this key.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this key.
+	// The name for this key. The name is unique across all keys in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -46953,7 +46988,7 @@ type LoadBalancer struct {
 	// The logging configuration for this load balancer.
 	Logging *LoadBalancerLogging `json:"logging" validate:"required"`
 
-	// The unique user-defined name for this load balancer.
+	// The name for this load balancer. The name is unique across all load balancers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The operating status of this load balancer.
@@ -47766,7 +47801,8 @@ type LoadBalancerListenerPolicy struct {
 	// The policy's unique identifier.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this policy.
+	// The name for this load balancer listener policy. The name is unique across all policies for the load balancer
+	// listener.
 	Name *string `json:"name" validate:"required"`
 
 	// Priority of the policy. Lower value indicates higher priority.
@@ -47877,7 +47913,7 @@ func UnmarshalLoadBalancerListenerPolicyCollection(m map[string]json.RawMessage,
 
 // LoadBalancerListenerPolicyPatch : LoadBalancerListenerPolicyPatch struct
 type LoadBalancerListenerPolicyPatch struct {
-	// The user-defined name for this policy. Names must be unique within the load balancer listener the policy resides in.
+	// The name for this policy. The name must not be used by another policy for the load balancer listener.
 	Name *string `json:"name,omitempty"`
 
 	// Priority of the policy. Lower value indicates higher priority.
@@ -47928,7 +47964,8 @@ type LoadBalancerListenerPolicyPrototype struct {
 	// unexpected property value was encountered.
 	Action *string `json:"action" validate:"required"`
 
-	// The user-defined name for this policy. Names must be unique within the load balancer listener the policy resides in.
+	// The name for this policy. The name must not be used by another policy for the load balancer listener. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// Priority of the policy. Lower value indicates higher priority.
@@ -48005,6 +48042,8 @@ type LoadBalancerListenerPolicyReference struct {
 
 	// The policy's unique identifier.
 	ID *string `json:"id" validate:"required"`
+
+	Name interface{} `json:"name" validate:"required"`
 }
 
 // UnmarshalLoadBalancerListenerPolicyReference unmarshals an instance of LoadBalancerListenerPolicyReference from the specified map of raw messages.
@@ -48019,6 +48058,10 @@ func UnmarshalLoadBalancerListenerPolicyReference(m map[string]json.RawMessage, 
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
 	if err != nil {
 		return
 	}
@@ -48403,7 +48446,7 @@ type LoadBalancerListenerPolicyTarget struct {
 	// The unique identifier for this load balancer pool.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name is unique across all pools for the load balancer.
 	Name *string `json:"name,omitempty"`
 
 	// The HTTP status code for this redirect.
@@ -48843,7 +48886,7 @@ type LoadBalancerPatch struct {
 	// To activate logging, the load balancer profile must support the specified logging type.
 	Logging *LoadBalancerLogging `json:"logging,omitempty"`
 
-	// The unique user-defined name for this load balancer.
+	// The name for this load balancer. The name must not be used by another load balancer in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// The subnets to provision this load balancer in. The load balancer's availability will depend on the availability of
@@ -48908,7 +48951,7 @@ type LoadBalancerPool struct {
 	// The backend server members of the pool.
 	Members []LoadBalancerPoolMemberReference `json:"members,omitempty"`
 
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name is unique across all pools for the load balancer.
 	Name *string `json:"name" validate:"required"`
 
 	// The protocol for this load balancer pool.
@@ -49325,7 +49368,7 @@ func UnmarshalLoadBalancerPoolIdentity(m map[string]json.RawMessage, result inte
 
 // LoadBalancerPoolIdentityByName : LoadBalancerPoolIdentityByName struct
 type LoadBalancerPoolIdentityByName struct {
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name is unique across all pools for the load balancer.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -49641,7 +49684,7 @@ type LoadBalancerPoolMemberTarget struct {
 	// The unique identifier for this virtual server instance.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name is unique across all virtual server instances in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address.
@@ -49754,7 +49797,7 @@ type LoadBalancerPoolPatch struct {
 	// The health monitor of this pool.
 	HealthMonitor *LoadBalancerPoolHealthMonitorPatch `json:"health_monitor,omitempty"`
 
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name must not be used by another pool for the load balancer.
 	Name *string `json:"name,omitempty"`
 
 	// The protocol for this load balancer pool.
@@ -49869,8 +49912,8 @@ type LoadBalancerPoolPrototype struct {
 	// tuple cannot be shared by a pool member of any other load balancer in the same VPC.
 	Members []LoadBalancerPoolMemberPrototype `json:"members,omitempty"`
 
-	// The user-defined name for this load balancer pool. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this load balancer pool. The name must not be used by another pool for the load balancer. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The protocol used for this load balancer pool. Load balancers in the `network` family support `tcp` and `udp` (if
@@ -49980,7 +50023,7 @@ type LoadBalancerPoolReference struct {
 	// The unique identifier for this load balancer pool.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name is unique across all pools for the load balancer.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -50160,7 +50203,7 @@ type LoadBalancerPrivateIpsItem struct {
 	// The unique identifier for this reserved IP.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined or system-provided name for this reserved IP.
+	// The name for this reserved IP. The name is unique across all reserved IPs in a subnet.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -50641,7 +50684,7 @@ type NetworkACL struct {
 	// The unique identifier for this network ACL.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network ACL.
+	// The name for this network ACL. The name is unique across all network ACLs for the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this network ACL.
@@ -50837,7 +50880,7 @@ func UnmarshalNetworkACLIdentity(m map[string]json.RawMessage, result interface{
 
 // NetworkACLPatch : NetworkACLPatch struct
 type NetworkACLPatch struct {
-	// The user-defined name for this network ACL. Names must be unique within the VPC the network ACL resides in.
+	// The name for this network ACL. The name must not be used by another network ACL for the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -50867,8 +50910,8 @@ func (networkACLPatch *NetworkACLPatch) AsPatch() (_patch map[string]interface{}
 // - NetworkACLPrototypeNetworkACLByRules
 // - NetworkACLPrototypeNetworkACLBySourceNetworkACL
 type NetworkACLPrototype struct {
-	// The user-defined name for this network ACL. Names must be unique within the VPC the network ACL resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL. The name must not be used by another network ACL for the VPC. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -50936,7 +50979,7 @@ type NetworkACLReference struct {
 	// The unique identifier for this network ACL.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network ACL.
+	// The name for this network ACL. The name is unique across all network ACLs for the VPC.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -51015,7 +51058,7 @@ type NetworkACLRule struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The protocol to enforce.
@@ -51308,7 +51351,7 @@ type NetworkACLRuleItem struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The protocol to enforce.
@@ -51429,7 +51472,7 @@ type NetworkACLRulePatch struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction,omitempty"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL.
 	Name *string `json:"name,omitempty"`
 
 	// The protocol to enforce.
@@ -51560,8 +51603,8 @@ type NetworkACLRulePrototype struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The protocol to enforce.
@@ -51666,8 +51709,8 @@ type NetworkACLRulePrototypeNetworkACLContext struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The protocol to enforce.
@@ -51769,7 +51812,7 @@ type NetworkACLRuleReference struct {
 	// The unique identifier for this network ACL rule.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -51832,7 +51875,7 @@ type NetworkInterface struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interface port speed in Mbps.
@@ -51949,7 +51992,7 @@ type NetworkInterfaceBareMetalServerContextReference struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	PrimaryIP *ReservedIPReference `json:"primary_ip" validate:"required"`
@@ -52040,9 +52083,9 @@ type NetworkInterfaceIPPrototype struct {
 	// `target` is deleted, or the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the subnet the reserved IP resides in. Names beginning with `ibm-` are reserved
-	// for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated
+	// list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -52093,7 +52136,7 @@ type NetworkInterfaceInstanceContextReference struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	PrimaryIP *ReservedIPReference `json:"primary_ip" validate:"required"`
@@ -52170,8 +52213,8 @@ type NetworkInterfacePatch struct {
 	// interface. If true, source IP spoofing is allowed on this interface.
 	AllowIPSpoofing *bool `json:"allow_ip_spoofing,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in.
+	// The name for network interface. The name must not be used by another network interface on the virtual server
+	// instance.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -52206,8 +52249,8 @@ type NetworkInterfacePrototype struct {
 	// interface. If true, source IP spoofing is allowed on this interface.
 	AllowIPSpoofing *bool `json:"allow_ip_spoofing,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for network interface. The name must not be used by another network interface on the virtual server
+	// instance. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using
@@ -52541,7 +52584,7 @@ type PlacementGroup struct {
 	// The lifecycle state of the placement group.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The user-defined name for this placement group.
+	// The name for this placement group. The name is unique across all placement groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this placement group.
@@ -52728,7 +52771,7 @@ func UnmarshalPlacementGroupCollectionNext(m map[string]json.RawMessage, result 
 
 // PlacementGroupPatch : PlacementGroupPatch struct
 type PlacementGroupPatch struct {
-	// The user-defined name for this placement group.
+	// The name for this placement group. The name must not be used by another placement group in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -52788,7 +52831,7 @@ type PublicGateway struct {
 	// The unique identifier for this public gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this public gateway.
+	// The name for this public gateway. The name is unique across all public gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this public gateway.
@@ -52983,7 +53026,7 @@ type PublicGatewayFloatingIP struct {
 	// The unique identifier for this floating IP.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this floating IP.
+	// The name for this floating IP. The name is unique across all floating IPs in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -53035,8 +53078,8 @@ type PublicGatewayFloatingIPPrototype struct {
 	// The globally unique IP address.
 	Address *string `json:"address,omitempty"`
 
-	// The unique user-defined name for this floating IP. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this floating IP. The name must not be used by another floating IP in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -53128,7 +53171,7 @@ func UnmarshalPublicGatewayIdentity(m map[string]json.RawMessage, result interfa
 
 // PublicGatewayPatch : PublicGatewayPatch struct
 type PublicGatewayPatch struct {
-	// The user-defined name for this public gateway. Names must be unique within the VPC the public gateway resides in.
+	// The name for this public gateway. The name must not be used by another public gateway in the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -53168,7 +53211,7 @@ type PublicGatewayReference struct {
 	// The unique identifier for this public gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this public gateway.
+	// The name for this public gateway. The name is unique across all public gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -53717,7 +53760,7 @@ type ReservedIP struct {
 	// The lifecycle state of the reserved IP.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The user-defined or system-provided name for this reserved IP.
+	// The name for this reserved IP. The name is unique across all reserved IPs in a subnet.
 	Name *string `json:"name" validate:"required"`
 
 	// The owner of the reserved IP.
@@ -54086,8 +54129,8 @@ type ReservedIPPatch struct {
 	// `target` is deleted, or the reserved IP is unbound. Must be `false` if the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. Names must be unique within the subnet the reserved IP resides in. Names
-	// beginning with `ibm-` are reserved for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -54137,7 +54180,7 @@ type ReservedIPReference struct {
 	// The unique identifier for this reserved IP.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined or system-provided name for this reserved IP.
+	// The name for this reserved IP. The name is unique across all reserved IPs in a subnet.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -54223,7 +54266,7 @@ type ReservedIPTarget struct {
 	// The unique identifier for this endpoint gateway.
 	ID *string `json:"id,omitempty"`
 
-	// The unique user-defined name for this endpoint gateway.
+	// The name for this endpoint gateway. The name is unique across all endpoint gateways in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -54374,7 +54417,7 @@ type ResourceGroupReference struct {
 	// The unique identifier for this resource group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this resource group.
+	// The name for this resource group.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -54454,7 +54497,7 @@ type Route struct {
 	// The lifecycle state of the route.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The user-defined name for this route.
+	// The name for this route. The name is unique across all routes in the routing table.
 	Name *string `json:"name" validate:"required"`
 
 	// If `action` is `deliver`, the next hop that packets will be delivered to.  For
@@ -54676,7 +54719,7 @@ type RouteCreator struct {
 	// The unique identifier for this VPN gateway.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -54750,7 +54793,7 @@ type RouteNextHop struct {
 	// The unique identifier for this VPN gateway connection.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this VPN connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -54804,7 +54847,8 @@ func UnmarshalRouteNextHop(m map[string]json.RawMessage, result interface{}) (er
 
 // RoutePatch : RoutePatch struct
 type RoutePatch struct {
-	// The user-defined name for this route. Names must be unique within the VPC routing table the route resides in.
+	// The name for this route. The name must not be used by another route in the routing table. Names starting with `ibm-`
+	// are reserved for system-provided routes, and are not allowed.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -54842,8 +54886,9 @@ type RoutePrototype struct {
 	// both routes have an `action` of `deliver` and the `next_hop` is an IP address.
 	Destination *string `json:"destination" validate:"required"`
 
-	// The user-defined name for this route. If unspecified, the name will be a hyphenated list of randomly-selected words.
-	// Names must be unique within the VPC routing table the route resides in.
+	// The name for this route. The name must not be used by another route in the routing table. Names starting with `ibm-`
+	// are reserved for system-provided routes, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// If `action` is `deliver`, the next hop that packets will be delivered to. For other `action`
@@ -54964,7 +55009,7 @@ type RouteReference struct {
 	// The unique identifier for this route.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this route.
+	// The name for this route. The name is unique across all routes in the routing table.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -55032,7 +55077,7 @@ type RoutingTable struct {
 	// The lifecycle state of the routing table.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The user-defined name for this routing table.
+	// The name for this routing table. The name is unique across all routing tables for the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -55302,7 +55347,7 @@ type RoutingTablePatch struct {
 	// support is expected to expand in the future.
 	AcceptRoutesFrom []ResourceFilter `json:"accept_routes_from,omitempty"`
 
-	// The user-defined name for this routing table. Names must be unique within the VPC the routing table resides in.
+	// The name for this routing table. The name must not be used by another routing table in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// Indicates whether this routing table is used to route traffic that originates from
@@ -55409,7 +55454,7 @@ type RoutingTableReference struct {
 	// The unique identifier for this routing table.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this routing table.
+	// The name for this routing table. The name is unique across all routing tables for the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -55481,7 +55526,7 @@ type SecurityGroup struct {
 	// The unique identifier for this security group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name is unique across all security groups for the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this security group.
@@ -55677,7 +55722,7 @@ func UnmarshalSecurityGroupIdentity(m map[string]json.RawMessage, result interfa
 
 // SecurityGroupPatch : SecurityGroupPatch struct
 type SecurityGroupPatch struct {
-	// The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name must not be used by another security group for the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -55717,7 +55762,7 @@ type SecurityGroupReference struct {
 	// The unique identifier for this security group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name is unique across all security groups for the VPC.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -56121,7 +56166,7 @@ type SecurityGroupRuleRemote struct {
 	// The unique identifier for this security group.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name is unique across all security groups for the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -56411,7 +56456,7 @@ type SecurityGroupTargetReference struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id,omitempty"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name,omitempty"`
 
 	// The resource type.
@@ -56525,6 +56570,7 @@ type Snapshot struct {
 	CRN *string `json:"crn" validate:"required"`
 
 	// Indicates whether this snapshot can be deleted. This value will always be `true`.
+	// Deprecated: this field is deprecated and may be removed in a future release.
 	Deletable *bool `json:"deletable" validate:"required"`
 
 	// The type of encryption used on the source volume.
@@ -56549,7 +56595,7 @@ type Snapshot struct {
 	// capacity of the `source_volume`.
 	MinimumCapacity *int64 `json:"minimum_capacity" validate:"required"`
 
-	// The user-defined name for this snapshot.
+	// The name for this snapshot. The name is unique across all snapshots in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The operating system included in this image.
@@ -56833,7 +56879,7 @@ func UnmarshalSnapshotIdentity(m map[string]json.RawMessage, result interface{})
 
 // SnapshotPatch : SnapshotPatch struct
 type SnapshotPatch struct {
-	// The user-defined name for this snapshot.
+	// The name for this snapshot. The name must not be used by another snapshot in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The [user tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) associated with this snapshot.
@@ -56869,8 +56915,8 @@ func (snapshotPatch *SnapshotPatch) AsPatch() (_patch map[string]interface{}, er
 // Models which "extend" this model:
 // - SnapshotPrototypeSnapshotBySourceVolume
 type SnapshotPrototype struct {
-	// The unique user-defined name for this snapshot. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this snapshot. The name must not be used by another snapshot in the region. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -56930,7 +56976,7 @@ type SnapshotReference struct {
 	// The unique identifier for this snapshot.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this snapshot.
+	// The name for this snapshot. The name is unique across all snapshots in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -57093,7 +57139,7 @@ type Subnet struct {
 	// The IPv4 range of the subnet, expressed in CIDR format.
 	Ipv4CIDRBlock *string `json:"ipv4_cidr_block" validate:"required"`
 
-	// The user-defined name for this subnet.
+	// The name for this subnet. The name is unique across all subnets in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The network ACL for this subnet.
@@ -57360,7 +57406,7 @@ func UnmarshalSubnetIdentity(m map[string]json.RawMessage, result interface{}) (
 
 // SubnetPatch : SubnetPatch struct
 type SubnetPatch struct {
-	// The user-defined name for this subnet. Names must be unique within the VPC the subnet resides in.
+	// The name for this subnet. The name must not be used by another subnet in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// The network ACL to use for this subnet.
@@ -57416,8 +57462,8 @@ type SubnetPrototype struct {
 	// The IP version(s) to support for this subnet.
 	IPVersion *string `json:"ip_version,omitempty"`
 
-	// The user-defined name for this subnet. Names must be unique within the VPC the subnet resides in. If unspecified,
-	// the name will be a hyphenated list of randomly-selected words.
+	// The name for this subnet. The name must not be used by another subnet in the VPC. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The network ACL to use for this subnet.
@@ -57574,7 +57620,7 @@ type SubnetReference struct {
 	// The unique identifier for this subnet.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this subnet.
+	// The name for this subnet. The name is unique across all subnets in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -60082,7 +60128,7 @@ type VPC struct {
 	// The unique identifier for this VPC.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPC.
+	// The name for this VPC. The name is unique across all VPCs in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this VPC.
@@ -60330,7 +60376,7 @@ func UnmarshalVPCIdentity(m map[string]json.RawMessage, result interface{}) (err
 
 // VPCPatch : VPCPatch struct
 type VPCPatch struct {
-	// The unique user-defined name for this VPC.
+	// The name for this VPC. The name must not be used by another VPC in the region.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -60370,7 +60416,7 @@ type VPCReference struct {
 	// The unique identifier for this VPC.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPC.
+	// The name for this VPC. The name is unique across all VPCs in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -60455,7 +60501,7 @@ type VPNGateway struct {
 	// Collection of VPN gateway members.
 	Members []VPNGatewayMember `json:"members" validate:"required"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this VPN gateway.
@@ -60690,7 +60736,7 @@ type VPNGatewayConnection struct {
 	// The mode of the VPN gateway.
 	Mode *string `json:"mode" validate:"required"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name" validate:"required"`
 
 	// The IP address of the peer VPN gateway.
@@ -61153,7 +61199,7 @@ type VPNGatewayConnectionPatch struct {
 	// auto-negotiation](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
 	IpsecPolicy VPNGatewayConnectionIPsecPolicyPatchIntf `json:"ipsec_policy,omitempty"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name must not be used by another connection for the VPN gateway.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the peer VPN gateway.
@@ -61265,7 +61311,8 @@ type VPNGatewayConnectionPrototype struct {
 	// used](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn&interface=ui#ipsec-auto-negotiation-phase-2).
 	IpsecPolicy VPNGatewayConnectionIPsecPolicyPrototypeIntf `json:"ipsec_policy,omitempty"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name must not be used by another connection for the VPN gateway. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the peer VPN gateway.
@@ -61357,7 +61404,7 @@ type VPNGatewayConnectionReference struct {
 	// The unique identifier for this VPN gateway connection.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this VPN connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -61504,7 +61551,7 @@ func UnmarshalVPNGatewayMember(m map[string]json.RawMessage, result interface{})
 
 // VPNGatewayPatch : VPNGatewayPatch struct
 type VPNGatewayPatch struct {
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name must not be used by another VPN gateway in the VPC.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -61534,7 +61581,8 @@ func (vpnGatewayPatch *VPNGatewayPatch) AsPatch() (_patch map[string]interface{}
 // - VPNGatewayPrototypeVPNGatewayRouteModePrototype
 // - VPNGatewayPrototypeVPNGatewayPolicyModePrototype
 type VPNGatewayPrototype struct {
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name must not be used by another VPN gateway in the VPC. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -61661,7 +61709,7 @@ type VPNServer struct {
 	// The lifecycle state of the VPN server.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The unique user-defined name for this VPN server.
+	// The name for this VPN server. The name is unique across all VPN servers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The port number used by this VPN server.
@@ -62322,7 +62370,7 @@ type VPNServerPatch struct {
 	// Indicates whether the split tunneling is enabled on this VPN server.
 	EnableSplitTunneling *bool `json:"enable_split_tunneling,omitempty"`
 
-	// The user-defined name for this VPN server. Names must be unique within the VPC this VPN server is serving.
+	// The name for this VPN server. The name must not be used by another VPN server in the VPC.
 	Name *string `json:"name,omitempty"`
 
 	// The port number used by this VPN server.
@@ -62445,7 +62493,7 @@ type VPNServerRoute struct {
 	// The lifecycle state of the VPN route.
 	LifecycleState *string `json:"lifecycle_state" validate:"required"`
 
-	// The user-defined name for this VPN route.
+	// The name for this VPN route. The name is unique across all routes for a VPN server.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -62618,7 +62666,7 @@ func UnmarshalVPNServerRouteCollectionNext(m map[string]json.RawMessage, result 
 
 // VPNServerRoutePatch : VPNServerRoutePatch struct
 type VPNServerRoutePatch struct {
-	// The user-defined name for this VPN route. Names must be unique within the VPN server the VPN route resides in.
+	// The name for this VPN server route. The name must not be used by another route for the VPN server.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -62674,6 +62722,22 @@ type Volume struct {
 	// `user_managed`.
 	EncryptionKey *EncryptionKeyReference `json:"encryption_key,omitempty"`
 
+	// The reasons for the current `health_state` (if any).
+	//
+	// The enumerated reason code values for this property will expand in the future. When processing this property, check
+	// for and log unknown values. Optionally halt processing and surface the error, or bypass the resource on which the
+	// unexpected reason code was encountered.
+	HealthReasons []VolumeHealthReason `json:"health_reasons" validate:"required"`
+
+	// The health of this resource.
+	// - `ok`: No abnormal behavior detected
+	// - `degraded`: Experiencing compromised performance, capacity, or connectivity
+	// - `faulted`: Completely unreachable, inoperative, or otherwise entirely incapacitated
+	// - `inapplicable`: The health state does not apply because of the current lifecycle state. A resource with a
+	// lifecycle state of `failed` or `deleting` will have a health state of `inapplicable`. A `pending` resource may also
+	// have this state.
+	HealthState *string `json:"health_state" validate:"required"`
+
 	// The URL for this volume.
 	Href *string `json:"href" validate:"required"`
 
@@ -62684,7 +62748,7 @@ type Volume struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops" validate:"required"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name is unique across all volumes in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The operating system associated with this volume. If absent, this volume was not
@@ -62737,6 +62801,21 @@ const (
 	VolumeEncryptionUserManagedConst     = "user_managed"
 )
 
+// Constants associated with the Volume.HealthState property.
+// The health of this resource.
+// - `ok`: No abnormal behavior detected
+// - `degraded`: Experiencing compromised performance, capacity, or connectivity
+// - `faulted`: Completely unreachable, inoperative, or otherwise entirely incapacitated
+// - `inapplicable`: The health state does not apply because of the current lifecycle state. A resource with a lifecycle
+// state of `failed` or `deleting` will have a health state of `inapplicable`. A `pending` resource may also have this
+// state.
+const (
+	VolumeHealthStateDegradedConst     = "degraded"
+	VolumeHealthStateFaultedConst      = "faulted"
+	VolumeHealthStateInapplicableConst = "inapplicable"
+	VolumeHealthStateOkConst           = "ok"
+)
+
 // Constants associated with the Volume.Status property.
 // The status of the volume.
 //
@@ -62784,6 +62863,14 @@ func UnmarshalVolume(m map[string]json.RawMessage, result interface{}) (err erro
 		return
 	}
 	err = core.UnmarshalModel(m, "encryption_key", &obj.EncryptionKey, UnmarshalEncryptionKeyReference)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "health_reasons", &obj.HealthReasons, UnmarshalVolumeHealthReason)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "health_state", &obj.HealthState)
 	if err != nil {
 		return
 	}
@@ -62856,7 +62943,7 @@ type VolumeAttachment struct {
 	// The date and time that the volume was attached.
 	CreatedAt *strfmt.DateTime `json:"created_at" validate:"required"`
 
-	// If set to true, when deleting the instance the volume will also be deleted.
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete" validate:"required"`
 
 	// Information about how the volume is exposed to the instance operating system.
@@ -62870,7 +62957,7 @@ type VolumeAttachment struct {
 	// The unique identifier for this volume attachment.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this volume attachment.
+	// The name for this volume attachment. The name is unique across all volume attachments on the instance.
 	Name *string `json:"name" validate:"required"`
 
 	// The status of this volume attachment.
@@ -62984,11 +63071,10 @@ func UnmarshalVolumeAttachmentDevice(m map[string]json.RawMessage, result interf
 
 // VolumeAttachmentPatch : VolumeAttachmentPatch struct
 type VolumeAttachmentPatch struct {
-	// If set to true, when deleting the instance the volume will also be deleted.
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
 
-	// The user-defined name for this volume attachment. Names must be unique within the instance the volume attachment
-	// resides in.
+	// The name for this volume attachment. The name must not be used by another volume attachment on the instance.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -63017,13 +63103,54 @@ func (volumeAttachmentPatch *VolumeAttachmentPatch) AsPatch() (_patch map[string
 	return
 }
 
-// VolumeAttachmentPrototypeInstanceByImageContext : VolumeAttachmentPrototypeInstanceByImageContext struct
-type VolumeAttachmentPrototypeInstanceByImageContext struct {
-	// If set to true, when deleting the instance the volume will also be deleted.
+// VolumeAttachmentPrototype : VolumeAttachmentPrototype struct
+type VolumeAttachmentPrototype struct {
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
 
-	// The user-defined name for this volume attachment. Names must be unique within the instance the volume attachment
-	// resides in.
+	// The name for this volume attachment. The name must not be used by another volume attachment on the instance. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	Name *string `json:"name,omitempty"`
+
+	// An existing volume to attach to the instance, or a prototype object for a new volume.
+	Volume VolumeAttachmentPrototypeVolumeIntf `json:"volume" validate:"required"`
+}
+
+// NewVolumeAttachmentPrototype : Instantiate VolumeAttachmentPrototype (Generic Model Constructor)
+func (*VpcV1) NewVolumeAttachmentPrototype(volume VolumeAttachmentPrototypeVolumeIntf) (_model *VolumeAttachmentPrototype, err error) {
+	_model = &VolumeAttachmentPrototype{
+		Volume: volume,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalVolumeAttachmentPrototype unmarshals an instance of VolumeAttachmentPrototype from the specified map of raw messages.
+func UnmarshalVolumeAttachmentPrototype(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(VolumeAttachmentPrototype)
+	err = core.UnmarshalPrimitive(m, "delete_volume_on_instance_delete", &obj.DeleteVolumeOnInstanceDelete)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "volume", &obj.Volume, UnmarshalVolumeAttachmentPrototypeVolume)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// VolumeAttachmentPrototypeInstanceByImageContext : VolumeAttachmentPrototypeInstanceByImageContext struct
+type VolumeAttachmentPrototypeInstanceByImageContext struct {
+	// Indicates whether deleting the instance will also delete the attached volume.
+	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
+
+	// The name for this volume attachment. The name must not be used by another volume attachment on the instance. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// A prototype object for a new volume.
@@ -63060,11 +63187,11 @@ func UnmarshalVolumeAttachmentPrototypeInstanceByImageContext(m map[string]json.
 
 // VolumeAttachmentPrototypeInstanceBySourceSnapshotContext : VolumeAttachmentPrototypeInstanceBySourceSnapshotContext struct
 type VolumeAttachmentPrototypeInstanceBySourceSnapshotContext struct {
-	// If set to true, when deleting the instance the volume will also be deleted.
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
 
-	// The user-defined name for this volume attachment. Names must be unique within the instance the volume attachment
-	// resides in.
+	// The name for this volume attachment. The name must not be used by another volume attachment on the instance. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// A prototype object for a new volume from a snapshot.
@@ -63099,47 +63226,6 @@ func UnmarshalVolumeAttachmentPrototypeInstanceBySourceSnapshotContext(m map[str
 	return
 }
 
-// VolumeAttachmentPrototypeInstanceContext : VolumeAttachmentPrototypeInstanceContext struct
-type VolumeAttachmentPrototypeInstanceContext struct {
-	// If set to true, when deleting the instance the volume will also be deleted.
-	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete,omitempty"`
-
-	// The user-defined name for this volume attachment. Names must be unique within the instance the volume attachment
-	// resides in.
-	Name *string `json:"name,omitempty"`
-
-	// An existing volume to attach to the instance, or a prototype object for a new volume.
-	Volume VolumeAttachmentVolumePrototypeInstanceContextIntf `json:"volume" validate:"required"`
-}
-
-// NewVolumeAttachmentPrototypeInstanceContext : Instantiate VolumeAttachmentPrototypeInstanceContext (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentPrototypeInstanceContext(volume VolumeAttachmentVolumePrototypeInstanceContextIntf) (_model *VolumeAttachmentPrototypeInstanceContext, err error) {
-	_model = &VolumeAttachmentPrototypeInstanceContext{
-		Volume: volume,
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-// UnmarshalVolumeAttachmentPrototypeInstanceContext unmarshals an instance of VolumeAttachmentPrototypeInstanceContext from the specified map of raw messages.
-func UnmarshalVolumeAttachmentPrototypeInstanceContext(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentPrototypeInstanceContext)
-	err = core.UnmarshalPrimitive(m, "delete_volume_on_instance_delete", &obj.DeleteVolumeOnInstanceDelete)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "volume", &obj.Volume, UnmarshalVolumeAttachmentVolumePrototypeInstanceContext)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
 // VolumeAttachmentPrototypeVolume : An existing volume to attach to the instance, or a prototype object for a new volume.
 // Models which "extend" this model:
 // - VolumeAttachmentPrototypeVolumeVolumeIdentity
@@ -63158,7 +63244,8 @@ type VolumeAttachmentPrototypeVolume struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
@@ -63253,7 +63340,7 @@ type VolumeAttachmentReferenceInstanceContext struct {
 	// The unique identifier for this volume attachment.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this volume attachment.
+	// The name for this volume attachment. The name is unique across all volume attachments on the instance.
 	Name *string `json:"name" validate:"required"`
 
 	// The attached volume.
@@ -63313,7 +63400,7 @@ func UnmarshalVolumeAttachmentReferenceInstanceContextDeleted(m map[string]json.
 
 // VolumeAttachmentReferenceVolumeContext : VolumeAttachmentReferenceVolumeContext struct
 type VolumeAttachmentReferenceVolumeContext struct {
-	// If set to true, when deleting the instance the volume will also be deleted.
+	// Indicates whether deleting the instance will also delete the attached volume.
 	DeleteVolumeOnInstanceDelete *bool `json:"delete_volume_on_instance_delete" validate:"required"`
 
 	// If present, this property indicates the referenced resource has been deleted, and provides
@@ -63334,7 +63421,7 @@ type VolumeAttachmentReferenceVolumeContext struct {
 	// The attached instance.
 	Instance *InstanceReference `json:"instance" validate:"required"`
 
-	// The user-defined name for this volume attachment.
+	// The name for this volume attachment. The name is unique across all volume attachments on the instance.
 	Name *string `json:"name" validate:"required"`
 
 	// The type of volume attachment.
@@ -63398,102 +63485,6 @@ type VolumeAttachmentReferenceVolumeContextDeleted struct {
 func UnmarshalVolumeAttachmentReferenceVolumeContextDeleted(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(VolumeAttachmentReferenceVolumeContextDeleted)
 	err = core.UnmarshalPrimitive(m, "more_info", &obj.MoreInfo)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContext : An existing volume to attach to the instance, or a prototype object for a new volume.
-// Models which "extend" this model:
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext
-type VolumeAttachmentVolumePrototypeInstanceContext struct {
-	// The unique identifier for this volume.
-	ID *string `json:"id,omitempty"`
-
-	// The CRN for this volume.
-	CRN *string `json:"crn,omitempty"`
-
-	// The URL for this volume.
-	Href *string `json:"href,omitempty"`
-
-	// The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a profile
-	// `family` of `custom`.
-	Iops *int64 `json:"iops,omitempty"`
-
-	// The unique user-defined name for this volume.
-	Name *string `json:"name,omitempty"`
-
-	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
-	// use for this volume.
-	Profile VolumeProfileIdentityIntf `json:"profile,omitempty"`
-
-	// The [user tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) associated with this volume.
-	UserTags []string `json:"user_tags,omitempty"`
-
-	// The capacity to use for the volume (in gigabytes). The specified minimum and maximum capacity values for creating or
-	// updating volumes may expand in the future.
-	Capacity *int64 `json:"capacity,omitempty"`
-
-	// The root key to use to wrap the data encryption key for the volume.
-	//
-	// If unspecified, the `encryption` type for the volume will be `provider_managed`.
-	EncryptionKey EncryptionKeyIdentityIntf `json:"encryption_key,omitempty"`
-
-	// The snapshot from which to clone the volume.
-	SourceSnapshot SnapshotIdentityIntf `json:"source_snapshot,omitempty"`
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContext) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-type VolumeAttachmentVolumePrototypeInstanceContextIntf interface {
-	isaVolumeAttachmentVolumePrototypeInstanceContext() bool
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContext unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContext from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContext(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContext)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "crn", &obj.CRN)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "iops", &obj.Iops)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalVolumeProfileIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "user_tags", &obj.UserTags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "capacity", &obj.Capacity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "encryption_key", &obj.EncryptionKey, UnmarshalEncryptionKeyIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "source_snapshot", &obj.SourceSnapshot, UnmarshalSnapshotIdentity)
 	if err != nil {
 		return
 	}
@@ -63586,6 +63577,43 @@ func UnmarshalVolumeCollectionNext(m map[string]json.RawMessage, result interfac
 	return
 }
 
+// VolumeHealthReason : VolumeHealthReason struct
+type VolumeHealthReason struct {
+	// A snake case string succinctly identifying the reason for this health state.
+	Code *string `json:"code" validate:"required"`
+
+	// An explanation of the reason for this health state.
+	Message *string `json:"message" validate:"required"`
+
+	// Link to documentation about the reason for this health state.
+	MoreInfo *string `json:"more_info,omitempty"`
+}
+
+// Constants associated with the VolumeHealthReason.Code property.
+// A snake case string succinctly identifying the reason for this health state.
+const (
+	VolumeHealthReasonCodeInitializingFromSnapshotConst = "initializing_from_snapshot"
+)
+
+// UnmarshalVolumeHealthReason unmarshals an instance of VolumeHealthReason from the specified map of raw messages.
+func UnmarshalVolumeHealthReason(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(VolumeHealthReason)
+	err = core.UnmarshalPrimitive(m, "code", &obj.Code)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "message", &obj.Message)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "more_info", &obj.MoreInfo)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // VolumeIdentity : Identifies a volume by a unique property.
 // Models which "extend" this model:
 // - VolumeIdentityByID
@@ -63642,7 +63670,7 @@ type VolumePatch struct {
 	// `family` of `custom`. The volume must be attached as a data volume to a running virtual server instance.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region.
 	Name *string `json:"name,omitempty"`
 
 	// The profile to use for this volume. The requested profile must be in the same
@@ -63898,7 +63926,8 @@ type VolumePrototype struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
@@ -63996,7 +64025,8 @@ type VolumePrototypeInstanceByImageContext struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
@@ -64064,7 +64094,8 @@ type VolumePrototypeInstanceBySourceSnapshotContext struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
@@ -64138,7 +64169,7 @@ type VolumeReference struct {
 	// The unique identifier for this volume.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name is unique across all volumes in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -64359,7 +64390,7 @@ type BareMetalServerBootTargetBareMetalServerDiskReference struct {
 	// The unique identifier for this bare metal server disk.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this disk.
+	// The name for this bare metal server disk. The name is unique across all disks on the bare metal server.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -64487,7 +64518,7 @@ type BareMetalServerNetworkInterfaceByHiperSocket struct {
 	// The MAC address of the interface.  If absent, the value is not known.
 	MacAddress *string `json:"mac_address" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interface port speed in Mbps.
@@ -64654,7 +64685,7 @@ type BareMetalServerNetworkInterfaceByPci struct {
 	// The MAC address of the interface.  If absent, the value is not known.
 	MacAddress *string `json:"mac_address" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interface port speed in Mbps.
@@ -64834,7 +64865,7 @@ type BareMetalServerNetworkInterfaceByVlan struct {
 	// The MAC address of the interface.  If absent, the value is not known.
 	MacAddress *string `json:"mac_address" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The network interface port speed in Mbps.
@@ -65008,8 +65039,8 @@ type BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByHi
 	// This must be `true` when `interface_type` is `hipersocket`.
 	EnableInfrastructureNat *bool `json:"enable_infrastructure_nat,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a
@@ -65108,8 +65139,8 @@ type BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByPc
 	// This must be `true` when `interface_type` is `hipersocket`.
 	EnableInfrastructureNat *bool `json:"enable_infrastructure_nat,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a
@@ -65221,8 +65252,8 @@ type BareMetalServerNetworkInterfacePrototypeBareMetalServerNetworkInterfaceByVl
 	// This must be `true` when `interface_type` is `hipersocket`.
 	EnableInfrastructureNat *bool `json:"enable_infrastructure_nat,omitempty"`
 
-	// The user-defined name for network interface. Names must be unique within the instance the network interface resides
-	// in. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network interface. The name must not be used by another network interface on the bare metal
+	// server. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a
@@ -67098,8 +67129,8 @@ type DedicatedHostPrototypeDedicatedHostByGroup struct {
 	// If set to true, instances can be placed on this dedicated host.
 	InstancePlacementEnabled *bool `json:"instance_placement_enabled,omitempty"`
 
-	// The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this dedicated host. The name must not be used by another dedicated host in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-dh-profiles) to use for this dedicated host.
@@ -67158,8 +67189,8 @@ type DedicatedHostPrototypeDedicatedHostByZone struct {
 	// If set to true, instances can be placed on this dedicated host.
 	InstancePlacementEnabled *bool `json:"instance_placement_enabled,omitempty"`
 
-	// The unique user-defined name for this dedicated host. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this dedicated host. The name must not be used by another dedicated host in the region. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-dh-profiles) to use for this dedicated host.
@@ -67304,9 +67335,9 @@ type EndpointGatewayReservedIPReservedIPPrototypeTargetContext struct {
 	// `target` is deleted, or the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the subnet the reserved IP resides in. Names beginning with `ibm-` are reserved
-	// for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated
+	// list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The subnet in which to create this reserved IP.
@@ -67580,8 +67611,8 @@ func UnmarshalFloatingIPByTargetNetworkInterfaceIdentityNetworkInterfaceIdentity
 // FloatingIPPrototypeFloatingIPByTarget : FloatingIPPrototypeFloatingIPByTarget struct
 // This model "extends" FloatingIPPrototype
 type FloatingIPPrototypeFloatingIPByTarget struct {
-	// The unique user-defined name for this floating IP. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this floating IP. The name must not be used by another floating IP in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -67625,8 +67656,8 @@ func UnmarshalFloatingIPPrototypeFloatingIPByTarget(m map[string]json.RawMessage
 // FloatingIPPrototypeFloatingIPByZone : FloatingIPPrototypeFloatingIPByZone struct
 // This model "extends" FloatingIPPrototype
 type FloatingIPPrototypeFloatingIPByZone struct {
-	// The unique user-defined name for this floating IP. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this floating IP. The name must not be used by another floating IP in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -67742,7 +67773,7 @@ type FloatingIPTargetNetworkInterfaceReference struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	PrimaryIP *ReservedIPReference `json:"primary_ip" validate:"required"`
@@ -67808,7 +67839,7 @@ type FloatingIPTargetPublicGatewayReference struct {
 	// The unique identifier for this public gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this public gateway.
+	// The name for this public gateway. The name is unique across all public gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -68060,7 +68091,7 @@ type FlowLogCollectorTargetInstanceReference struct {
 	// The unique identifier for this virtual server instance.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name is unique across all virtual server instances in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -68108,7 +68139,7 @@ type FlowLogCollectorTargetNetworkInterfaceReferenceTargetContext struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -68168,7 +68199,7 @@ type FlowLogCollectorTargetSubnetReference struct {
 	// The unique identifier for this subnet.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this subnet.
+	// The name for this subnet. The name is unique across all subnets in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -68232,7 +68263,7 @@ type FlowLogCollectorTargetVPCReference struct {
 	// The unique identifier for this VPC.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPC.
+	// The name for this VPC. The name is unique across all VPCs in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -68376,8 +68407,9 @@ func UnmarshalImageIdentityByID(m map[string]json.RawMessage, result interface{}
 // ImagePrototypeImageByFile : ImagePrototypeImageByFile struct
 // This model "extends" ImagePrototype
 type ImagePrototypeImageByFile struct {
-	// The unique user-defined name for this image. Names starting with `ibm-` are not allowed. If unspecified, the name
-	// will be a hyphenated list of randomly-selected words.
+	// The name for this image. The name must not be used by another image in the region. Names starting with `ibm-` are
+	// reserved for system-provided images, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -68456,8 +68488,9 @@ func UnmarshalImagePrototypeImageByFile(m map[string]json.RawMessage, result int
 // ImagePrototypeImageBySourceVolume : ImagePrototypeImageBySourceVolume struct
 // This model "extends" ImagePrototype
 type ImagePrototypeImageBySourceVolume struct {
-	// The unique user-defined name for this image. Names starting with `ibm-` are not allowed. If unspecified, the name
-	// will be a hyphenated list of randomly-selected words.
+	// The name for this image. The name must not be used by another image in the region. Names starting with `ibm-` are
+	// reserved for system-provided images, and are not allowed. If unspecified, the name will be a hyphenated list of
+	// randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -68583,7 +68616,7 @@ func UnmarshalInstanceCatalogOfferingPrototypeCatalogOfferingByVersion(m map[str
 // - InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec
 // This model "extends" InstanceGroupManagerActionPrototype
 type InstanceGroupManagerActionPrototypeScheduledActionPrototype struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -68664,7 +68697,8 @@ type InstanceGroupManagerActionScheduledAction struct {
 	// The unique identifier for this instance group manager action.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name is unique across all actions for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -68822,7 +68856,7 @@ type InstanceGroupManagerAutoScale struct {
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled" validate:"required"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name" validate:"required"`
 
 	// The date and time that the instance group manager was updated.
@@ -68915,7 +68949,7 @@ func UnmarshalInstanceGroupManagerAutoScale(m map[string]json.RawMessage, result
 // InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype : InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype struct
 // This model "extends" InstanceGroupManagerPolicyPrototype
 type InstanceGroupManagerPolicyPrototypeInstanceGroupManagerTargetPolicyPrototype struct {
-	// The user-defined name for this instance group manager policy. Names must be unique within the instance group
+	// The name for this instance group manager policy. The name must not be used by another policy for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -68994,7 +69028,8 @@ type InstanceGroupManagerPolicyInstanceGroupManagerTargetPolicy struct {
 	// The unique identifier for this instance group manager policy.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager policy.
+	// The name for this instance group manager policy. The name is unique across all policies for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The date and time that the instance group manager policy was updated.
@@ -69074,7 +69109,7 @@ type InstanceGroupManagerPrototypeInstanceGroupManagerAutoScalePrototype struct 
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled,omitempty"`
 
-	// The user-defined name for this instance group manager. Names must be unique within the instance group. If
+	// The name for this instance group manager. The name must not be used by another manager for the instance group. If
 	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -69155,7 +69190,7 @@ type InstanceGroupManagerPrototypeInstanceGroupManagerScheduledPrototype struct 
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled,omitempty"`
 
-	// The user-defined name for this instance group manager. Names must be unique within the instance group. If
+	// The name for this instance group manager. The name must not be used by another manager for the instance group. If
 	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -69216,7 +69251,7 @@ type InstanceGroupManagerScheduled struct {
 	// Indicates whether this manager will control the instance group.
 	ManagementEnabled *bool `json:"management_enabled" validate:"required"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name" validate:"required"`
 
 	// The date and time that the instance group manager was updated.
@@ -69291,7 +69326,7 @@ type InstanceGroupManagerScheduledActionManagerAutoScale struct {
 	// The unique identifier for this instance group manager.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager.
+	// The name for this instance group manager. The name is unique across all managers for the instance group.
 	Name *string `json:"name" validate:"required"`
 
 	// The desired maximum number of instance group members at the scheduled time.
@@ -69716,7 +69751,7 @@ type InstancePlacementTargetDedicatedHostGroupReference struct {
 	// The unique identifier for this dedicated host group.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this dedicated host group.
+	// The name for this dedicated host group. The name is unique across all dedicated host groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -69780,7 +69815,7 @@ type InstancePlacementTargetDedicatedHostReference struct {
 	// The unique identifier for this dedicated host.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this dedicated host.
+	// The name for this dedicated host. The name is unique across all dedicated hosts in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -69844,7 +69879,7 @@ type InstancePlacementTargetPlacementGroupReference struct {
 	// The unique identifier for this placement group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this placement group.
+	// The name for this placement group. The name is unique across all placement groups in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -71340,8 +71375,10 @@ type InstancePrototypeInstanceByCatalogOffering struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -71366,7 +71403,7 @@ type InstancePrototypeInstanceByCatalogOffering struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -71454,7 +71491,7 @@ func UnmarshalInstancePrototypeInstanceByCatalogOffering(m map[string]json.RawMe
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -71509,8 +71546,10 @@ type InstancePrototypeInstanceByImage struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -71535,7 +71574,7 @@ type InstancePrototypeInstanceByImage struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -71616,7 +71655,7 @@ func UnmarshalInstancePrototypeInstanceByImage(m map[string]json.RawMessage, res
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -71671,8 +71710,10 @@ type InstancePrototypeInstanceBySourceSnapshot struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -71697,7 +71738,7 @@ type InstancePrototypeInstanceBySourceSnapshot struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -71775,7 +71816,7 @@ func UnmarshalInstancePrototypeInstanceBySourceSnapshot(m map[string]json.RawMes
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -71826,8 +71867,10 @@ type InstancePrototypeInstanceBySourceTemplate struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this virtual server instance. The name must not be used by another virtual server instance in the
+	// region. If unspecified, the name will be a hyphenated list of randomly-selected words.
+	//
+	// The system hostname will be based on this name.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -71852,7 +71895,7 @@ type InstancePrototypeInstanceBySourceTemplate struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -71945,7 +71988,7 @@ func UnmarshalInstancePrototypeInstanceBySourceTemplate(m map[string]json.RawMes
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72101,8 +72144,8 @@ type InstanceTemplatePrototypeInstanceByCatalogOffering struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this instance template. The name must not be used by another instance template in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72127,7 +72170,7 @@ type InstanceTemplatePrototypeInstanceByCatalogOffering struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -72215,7 +72258,7 @@ func UnmarshalInstanceTemplatePrototypeInstanceByCatalogOffering(m map[string]js
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72270,8 +72313,8 @@ type InstanceTemplatePrototypeInstanceByImage struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this instance template. The name must not be used by another instance template in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72296,7 +72339,7 @@ type InstanceTemplatePrototypeInstanceByImage struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -72377,7 +72420,7 @@ func UnmarshalInstanceTemplatePrototypeInstanceByImage(m map[string]json.RawMess
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72432,8 +72475,8 @@ type InstanceTemplatePrototypeInstanceBySourceSnapshot struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this instance template. The name must not be used by another instance template in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72458,7 +72501,7 @@ type InstanceTemplatePrototypeInstanceBySourceSnapshot struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -72536,7 +72579,7 @@ func UnmarshalInstanceTemplatePrototypeInstanceBySourceSnapshot(m map[string]jso
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72587,8 +72630,8 @@ type InstanceTemplatePrototypeInstanceBySourceTemplate struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this virtual server instance (and default system hostname). If unspecified, the
-	// name will be a hyphenated list of randomly-selected words.
+	// The name for this instance template. The name must not be used by another instance template in the region. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72613,7 +72656,7 @@ type InstanceTemplatePrototypeInstanceBySourceTemplate struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -72706,7 +72749,7 @@ func UnmarshalInstanceTemplatePrototypeInstanceBySourceTemplate(m map[string]jso
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72781,7 +72824,7 @@ type InstanceTemplateInstanceByCatalogOffering struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name is unique across all instance templates in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72807,7 +72850,7 @@ type InstanceTemplateInstanceByCatalogOffering struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -72900,7 +72943,7 @@ func UnmarshalInstanceTemplateInstanceByCatalogOffering(m map[string]json.RawMes
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -72967,7 +73010,7 @@ type InstanceTemplateInstanceByImage struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name is unique across all instance templates in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -72993,7 +73036,7 @@ type InstanceTemplateInstanceByImage struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -73079,7 +73122,7 @@ func UnmarshalInstanceTemplateInstanceByImage(m map[string]json.RawMessage, resu
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -73146,7 +73189,7 @@ type InstanceTemplateInstanceBySourceSnapshot struct {
 
 	MetadataService *InstanceMetadataServicePrototype `json:"metadata_service,omitempty"`
 
-	// The unique user-defined name for this instance template.
+	// The name for this instance template. The name is unique across all instance templates in the region.
 	Name *string `json:"name" validate:"required"`
 
 	// The additional network interfaces to create for the virtual server instance.
@@ -73172,7 +73215,7 @@ type InstanceTemplateInstanceBySourceSnapshot struct {
 	UserData *string `json:"user_data,omitempty"`
 
 	// The additional volume attachments to create for the virtual server instance.
-	VolumeAttachments []VolumeAttachmentPrototypeInstanceContext `json:"volume_attachments,omitempty"`
+	VolumeAttachments []VolumeAttachmentPrototype `json:"volume_attachments,omitempty"`
 
 	// The VPC this virtual server instance will reside in.  If specified, it must match the VPC for the subnets of the
 	// instance's network interfaces.
@@ -73255,7 +73298,7 @@ func UnmarshalInstanceTemplateInstanceBySourceSnapshot(m map[string]json.RawMess
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototypeInstanceContext)
+	err = core.UnmarshalModel(m, "volume_attachments", &obj.VolumeAttachments, UnmarshalVolumeAttachmentPrototype)
 	if err != nil {
 		return
 	}
@@ -73899,7 +73942,7 @@ type LoadBalancerListenerPolicyTargetLoadBalancerPoolReference struct {
 	// The unique identifier for this load balancer pool.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this load balancer pool.
+	// The name for this load balancer pool. The name is unique across all pools for the load balancer.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -74118,7 +74161,7 @@ type LoadBalancerPoolMemberTargetInstanceReference struct {
 	// The unique identifier for this virtual server instance.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this virtual server instance (and default system hostname).
+	// The name for this virtual server instance. The name is unique across all virtual server instances in the region.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -74500,8 +74543,8 @@ func UnmarshalNetworkACLIdentityByID(m map[string]json.RawMessage, result interf
 // NetworkACLPrototypeNetworkACLByRules : NetworkACLPrototypeNetworkACLByRules struct
 // This model "extends" NetworkACLPrototype
 type NetworkACLPrototypeNetworkACLByRules struct {
-	// The user-defined name for this network ACL. Names must be unique within the VPC the network ACL resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL. The name must not be used by another network ACL for the VPC. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -74553,8 +74596,8 @@ func UnmarshalNetworkACLPrototypeNetworkACLByRules(m map[string]json.RawMessage,
 // NetworkACLPrototypeNetworkACLBySourceNetworkACL : NetworkACLPrototypeNetworkACLBySourceNetworkACL struct
 // This model "extends" NetworkACLPrototype
 type NetworkACLPrototypeNetworkACLBySourceNetworkACL struct {
-	// The user-defined name for this network ACL. Names must be unique within the VPC the network ACL resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL. The name must not be used by another network ACL for the VPC. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -74755,7 +74798,7 @@ type NetworkACLRuleItemNetworkACLRuleProtocolAll struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -74874,7 +74917,7 @@ type NetworkACLRuleItemNetworkACLRuleProtocolIcmp struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75011,7 +75054,7 @@ type NetworkACLRuleItemNetworkACLRuleProtocolTcpudp struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75143,8 +75186,8 @@ type NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolAllPrototype 
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75234,8 +75277,8 @@ type NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolIcmpPrototype
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75343,8 +75386,8 @@ type NetworkACLRulePrototypeNetworkACLContextNetworkACLRuleProtocolTcpudpPrototy
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75465,8 +75508,8 @@ type NetworkACLRulePrototypeNetworkACLRuleProtocolAllPrototype struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75562,8 +75605,8 @@ type NetworkACLRulePrototypeNetworkACLRuleProtocolIcmpPrototype struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75677,8 +75720,8 @@ type NetworkACLRulePrototypeNetworkACLRuleProtocolTcpudpPrototype struct {
 	// The direction of traffic to match.
 	Direction *string `json:"direction" validate:"required"`
 
-	// The user-defined name for this rule. Names must be unique within the network ACL the rule resides in. If
-	// unspecified, the name will be a hyphenated list of randomly-selected words.
+	// The name for this network ACL rule. The name must not be used by another rule for the network ACL. If unspecified,
+	// the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75816,7 +75859,7 @@ type NetworkACLRuleNetworkACLRuleProtocolAll struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -75934,7 +75977,7 @@ type NetworkACLRuleNetworkACLRuleProtocolIcmp struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -76070,7 +76113,7 @@ type NetworkACLRuleNetworkACLRuleProtocolTcpudp struct {
 	// The IP version for this rule.
 	IPVersion *string `json:"ip_version" validate:"required"`
 
-	// The user-defined name for this network ACL rule.
+	// The name for this network ACL rule. The name is unique across all rules for the network ACL.
 	Name *string `json:"name" validate:"required"`
 
 	// The source IP address or CIDR block to match. The CIDR block `0.0.0.0/0` matches all source addresses.
@@ -76243,9 +76286,9 @@ type NetworkInterfaceIPPrototypeReservedIPPrototypeNetworkInterfaceContext struc
 	// `target` is deleted, or the reserved IP is unbound.
 	AutoDelete *bool `json:"auto_delete,omitempty"`
 
-	// The user-defined name for this reserved IP. If unspecified, the name will be a hyphenated list of randomly-selected
-	// words. Names must be unique within the subnet the reserved IP resides in. Names beginning with `ibm-` are reserved
-	// for provider-owned resources.
+	// The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with
+	// `ibm-` are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated
+	// list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 }
 
@@ -76394,8 +76437,8 @@ func UnmarshalPublicGatewayFloatingIPPrototypeFloatingIPIdentity(m map[string]js
 // PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext : PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext struct
 // This model "extends" PublicGatewayFloatingIPPrototype
 type PublicGatewayFloatingIPPrototypeFloatingIPPrototypeTargetContext struct {
-	// The unique user-defined name for this floating IP. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this floating IP. The name must not be used by another floating IP in the region. If unspecified, the
+	// name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The resource group to use. If unspecified, the account's [default resource
@@ -76580,7 +76623,7 @@ type ReservedIPTargetEndpointGatewayReference struct {
 	// The unique identifier for this endpoint gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this endpoint gateway.
+	// The name for this endpoint gateway. The name is unique across all endpoint gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -76687,7 +76730,7 @@ type ReservedIPTargetLoadBalancerReference struct {
 	// The unique identifier for this load balancer.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this load balancer.
+	// The name for this load balancer. The name is unique across all load balancers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -76748,7 +76791,7 @@ type ReservedIPTargetNetworkInterfaceReferenceTargetContext struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -76808,7 +76851,7 @@ type ReservedIPTargetVPNGatewayReference struct {
 	// The unique identifier for this VPN gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -76872,7 +76915,7 @@ type ReservedIPTargetVPNServerReference struct {
 	// The unique identifier for this VPN server.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPN server.
+	// The name for this VPN server. The name is unique across all VPN servers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -76967,7 +77010,7 @@ type RouteCreatorVPNGatewayReference struct {
 	// The unique identifier for this VPN gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -77031,7 +77074,7 @@ type RouteCreatorVPNServerReference struct {
 	// The unique identifier for this VPN server.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPN server.
+	// The name for this VPN server. The name is unique across all VPN servers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -77118,7 +77161,7 @@ type RouteNextHopVPNGatewayConnectionReference struct {
 	// The unique identifier for this VPN gateway connection.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this VPN connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -77978,7 +78021,7 @@ type SecurityGroupRuleRemoteSecurityGroupReference struct {
 	// The unique identifier for this security group.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
+	// The name for this security group. The name is unique across all security groups for the VPC.
 	Name *string `json:"name" validate:"required"`
 }
 
@@ -78298,7 +78341,7 @@ type SecurityGroupTargetReferenceEndpointGatewayReference struct {
 	// The unique identifier for this endpoint gateway.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this endpoint gateway.
+	// The name for this endpoint gateway. The name is unique across all endpoint gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -78362,7 +78405,7 @@ type SecurityGroupTargetReferenceLoadBalancerReference struct {
 	// The unique identifier for this load balancer.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this load balancer.
+	// The name for this load balancer. The name is unique across all load balancers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -78423,7 +78466,7 @@ type SecurityGroupTargetReferenceNetworkInterfaceReferenceTargetContext struct {
 	// The unique identifier for this network interface.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this network interface.
+	// The name for this network interface.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -78483,7 +78526,7 @@ type SecurityGroupTargetReferenceVPNServerReference struct {
 	// The unique identifier for this VPN server.
 	ID *string `json:"id" validate:"required"`
 
-	// The unique user-defined name for this VPN server.
+	// The name for this VPN server. The name is unique across all VPN servers in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -78627,8 +78670,8 @@ func UnmarshalSnapshotIdentityByID(m map[string]json.RawMessage, result interfac
 // SnapshotPrototypeSnapshotBySourceVolume : SnapshotPrototypeSnapshotBySourceVolume struct
 // This model "extends" SnapshotPrototype
 type SnapshotPrototypeSnapshotBySourceVolume struct {
-	// The unique user-defined name for this snapshot. If unspecified, the name will be a hyphenated list of
-	// randomly-selected words.
+	// The name for this snapshot. The name must not be used by another snapshot in the region. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -78775,8 +78818,8 @@ type SubnetPrototypeSubnetByCIDR struct {
 	// The IP version(s) to support for this subnet.
 	IPVersion *string `json:"ip_version,omitempty"`
 
-	// The user-defined name for this subnet. Names must be unique within the VPC the subnet resides in. If unspecified,
-	// the name will be a hyphenated list of randomly-selected words.
+	// The name for this subnet. The name must not be used by another subnet in the VPC. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The network ACL to use for this subnet. If unspecified, the default network ACL for the VPC is used.
@@ -78877,8 +78920,8 @@ type SubnetPrototypeSubnetByTotalCount struct {
 	// The IP version(s) to support for this subnet.
 	IPVersion *string `json:"ip_version,omitempty"`
 
-	// The user-defined name for this subnet. Names must be unique within the VPC the subnet resides in. If unspecified,
-	// the name will be a hyphenated list of randomly-selected words.
+	// The name for this subnet. The name must not be used by another subnet in the VPC. If unspecified, the name will be a
+	// hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The network ACL to use for this subnet. If unspecified, the default network ACL for the VPC is used.
@@ -79479,7 +79522,7 @@ type VPNGatewayConnectionPatchVPNGatewayConnectionStaticRouteModePatch struct {
 
 	IpsecPolicy VPNGatewayConnectionIPsecPolicyPatchIntf `json:"ipsec_policy,omitempty"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name must not be used by another connection for the VPN gateway.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the peer VPN gateway.
@@ -79582,7 +79625,7 @@ type VPNGatewayConnectionPolicyMode struct {
 	// The mode of the VPN gateway.
 	Mode *string `json:"mode" validate:"required"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name" validate:"required"`
 
 	// The IP address of the peer VPN gateway.
@@ -79717,7 +79760,8 @@ type VPNGatewayConnectionPrototypeVPNGatewayConnectionPolicyModePrototype struct
 
 	IpsecPolicy VPNGatewayConnectionIPsecPolicyPrototypeIntf `json:"ipsec_policy,omitempty"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name must not be used by another connection for the VPN gateway. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the peer VPN gateway.
@@ -79804,7 +79848,8 @@ type VPNGatewayConnectionPrototypeVPNGatewayConnectionStaticRouteModePrototype s
 
 	IpsecPolicy VPNGatewayConnectionIPsecPolicyPrototypeIntf `json:"ipsec_policy,omitempty"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name must not be used by another connection for the VPN gateway. If
+	// unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The IP address of the peer VPN gateway.
@@ -79907,7 +79952,7 @@ type VPNGatewayConnectionStaticRouteMode struct {
 	// The mode of the VPN gateway.
 	Mode *string `json:"mode" validate:"required"`
 
-	// The user-defined name for this VPN gateway connection.
+	// The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
 	Name *string `json:"name" validate:"required"`
 
 	// The IP address of the peer VPN gateway.
@@ -80057,7 +80102,7 @@ type VPNGatewayPolicyMode struct {
 	// Collection of VPN gateway members.
 	Members []VPNGatewayMember `json:"members" validate:"required"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this VPN gateway.
@@ -80165,7 +80210,8 @@ func UnmarshalVPNGatewayPolicyMode(m map[string]json.RawMessage, result interfac
 // VPNGatewayPrototypeVPNGatewayPolicyModePrototype : VPNGatewayPrototypeVPNGatewayPolicyModePrototype struct
 // This model "extends" VPNGatewayPrototype
 type VPNGatewayPrototypeVPNGatewayPolicyModePrototype struct {
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name must not be used by another VPN gateway in the VPC. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -80221,7 +80267,8 @@ func UnmarshalVPNGatewayPrototypeVPNGatewayPolicyModePrototype(m map[string]json
 // VPNGatewayPrototypeVPNGatewayRouteModePrototype : VPNGatewayPrototypeVPNGatewayRouteModePrototype struct
 // This model "extends" VPNGatewayPrototype
 type VPNGatewayPrototypeVPNGatewayRouteModePrototype struct {
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name must not be used by another VPN gateway in the VPC. If unspecified, the name
+	// will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	ResourceGroup ResourceGroupIdentityIntf `json:"resource_group,omitempty"`
@@ -80295,7 +80342,7 @@ type VPNGatewayRouteMode struct {
 	// Collection of VPN gateway members.
 	Members []VPNGatewayMember `json:"members" validate:"required"`
 
-	// The user-defined name for this VPN gateway.
+	// The name for this VPN gateway. The name is unique across all VPN gateways in the VPC.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource group for this VPN gateway.
@@ -80684,7 +80731,8 @@ type VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
@@ -80723,136 +80771,6 @@ func (*VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext) isaVolumeA
 // UnmarshalVolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext unmarshals an instance of VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext from the specified map of raw messages.
 func UnmarshalVolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext)
-	err = core.UnmarshalPrimitive(m, "iops", &obj.Iops)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalVolumeProfileIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "user_tags", &obj.UserTags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "capacity", &obj.Capacity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "encryption_key", &obj.EncryptionKey, UnmarshalEncryptionKeyIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "source_snapshot", &obj.SourceSnapshot, UnmarshalSnapshotIdentity)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity : Identifies a volume by a unique property.
-// Models which "extend" this model:
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContext
-type VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity struct {
-	// The unique identifier for this volume.
-	ID *string `json:"id,omitempty"`
-
-	// The CRN for this volume.
-	CRN *string `json:"crn,omitempty"`
-
-	// The URL for this volume.
-	Href *string `json:"href,omitempty"`
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity) isaVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity() bool {
-	return true
-}
-
-type VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityIntf interface {
-	VolumeAttachmentVolumePrototypeInstanceContextIntf
-	isaVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity() bool
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "crn", &obj.CRN)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext : VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext struct
-// Models which "extend" this model:
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity
-// - VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContext
-type VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext struct {
-	// The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a profile
-	// `family` of `custom`.
-	Iops *int64 `json:"iops,omitempty"`
-
-	// The unique user-defined name for this volume.
-	Name *string `json:"name,omitempty"`
-
-	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to
-	// use for this volume.
-	Profile VolumeProfileIdentityIntf `json:"profile" validate:"required"`
-
-	// The [user tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) associated with this volume.
-	UserTags []string `json:"user_tags,omitempty"`
-
-	// The capacity to use for the volume (in gigabytes). The specified minimum and maximum capacity values for creating or
-	// updating volumes may expand in the future.
-	Capacity *int64 `json:"capacity,omitempty"`
-
-	// The root key to use to wrap the data encryption key for the volume.
-	//
-	// If unspecified, the `encryption` type for the volume will be `provider_managed`.
-	EncryptionKey EncryptionKeyIdentityIntf `json:"encryption_key,omitempty"`
-
-	// The snapshot from which to clone the volume.
-	SourceSnapshot SnapshotIdentityIntf `json:"source_snapshot,omitempty"`
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext) isaVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-type VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextIntf interface {
-	VolumeAttachmentVolumePrototypeInstanceContextIntf
-	isaVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext() bool
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext)
 	err = core.UnmarshalPrimitive(m, "iops", &obj.Iops)
 	if err != nil {
 		return
@@ -81047,7 +80965,8 @@ type VolumePrototypeVolumeByCapacity struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
@@ -81132,7 +81051,8 @@ type VolumePrototypeVolumeBySourceSnapshot struct {
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
@@ -81843,7 +81763,7 @@ func UnmarshalFlowLogCollectorTargetPrototypeVPCIdentityVPCIdentityByID(m map[st
 // - InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototype
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -81902,7 +81822,7 @@ func UnmarshalInstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronS
 // - InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototype
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -81976,7 +81896,8 @@ type InstanceGroupManagerActionScheduledActionGroupTarget struct {
 	// The unique identifier for this instance group manager action.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name is unique across all actions for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -82130,7 +82051,8 @@ type InstanceGroupManagerActionScheduledActionManagerTarget struct {
 	// The unique identifier for this instance group manager action.
 	ID *string `json:"id" validate:"required"`
 
-	// The user-defined name for this instance group manager action.
+	// The name for this instance group manager action. The name is unique across all actions for the instance group
+	// manager.
 	Name *string `json:"name" validate:"required"`
 
 	// The resource type.
@@ -83837,7 +83759,8 @@ type VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototyp
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
@@ -83912,7 +83835,8 @@ type VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolumePrototyp
 	// `family` of `custom`.
 	Iops *int64 `json:"iops,omitempty"`
 
-	// The unique user-defined name for this volume.
+	// The name for this volume. The name must not be used by another volume in the region. If unspecified, the name will
+	// be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
 	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
@@ -83989,274 +83913,10 @@ func UnmarshalVolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContextVolum
 	return
 }
 
-// VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN : VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN struct
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity
-type VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN struct {
-	// The CRN for this volume.
-	CRN *string `json:"crn" validate:"required"`
-}
-
-// NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN : Instantiate VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN(crn string) (_model *VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN, err error) {
-	_model = &VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN{
-		CRN: core.StringPtr(crn),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN) isaVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity() bool {
-	return true
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByCRN)
-	err = core.UnmarshalPrimitive(m, "crn", &obj.CRN)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref : VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref struct
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity
-type VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref struct {
-	// The URL for this volume.
-	Href *string `json:"href" validate:"required"`
-}
-
-// NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref : Instantiate VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref(href string) (_model *VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref, err error) {
-	_model = &VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref{
-		Href: core.StringPtr(href),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref) isaVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity() bool {
-	return true
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByHref)
-	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID : VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID struct
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity
-type VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID struct {
-	// The unique identifier for this volume.
-	ID *string `json:"id" validate:"required"`
-}
-
-// NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID : Instantiate VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID(id string) (_model *VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID, err error) {
-	_model = &VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID{
-		ID: core.StringPtr(id),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID) isaVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentity() bool {
-	return true
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumeIdentityVolumeIdentityByID)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity : VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity struct
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext
-type VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity struct {
-	// The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a profile
-	// `family` of `custom`.
-	Iops *int64 `json:"iops,omitempty"`
-
-	// The unique user-defined name for this volume.
-	Name *string `json:"name,omitempty"`
-
-	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
-	Profile VolumeProfileIdentityIntf `json:"profile" validate:"required"`
-
-	// The [user tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) associated with this volume.
-	UserTags []string `json:"user_tags,omitempty"`
-
-	// The capacity to use for the volume (in gigabytes). The specified minimum and maximum capacity values for creating or
-	// updating volumes may expand in the future.
-	Capacity *int64 `json:"capacity" validate:"required"`
-
-	// The root key to use to wrap the data encryption key for the volume.
-	//
-	// If unspecified, the `encryption` type for the volume will be `provider_managed`.
-	EncryptionKey EncryptionKeyIdentityIntf `json:"encryption_key,omitempty"`
-}
-
-// NewVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity : Instantiate VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity(profile VolumeProfileIdentityIntf, capacity int64) (_model *VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity, err error) {
-	_model = &VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity{
-		Profile:  profile,
-		Capacity: core.Int64Ptr(capacity),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity) isaVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeByCapacity)
-	err = core.UnmarshalPrimitive(m, "iops", &obj.Iops)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalVolumeProfileIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "user_tags", &obj.UserTags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "capacity", &obj.Capacity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "encryption_key", &obj.EncryptionKey, UnmarshalEncryptionKeyIdentity)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot : VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot struct
-// This model "extends" VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext
-type VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot struct {
-	// The maximum I/O operations per second (IOPS) to use for the volume. Applicable only to volumes using a profile
-	// `family` of `custom`.
-	Iops *int64 `json:"iops,omitempty"`
-
-	// The unique user-defined name for this volume.
-	Name *string `json:"name,omitempty"`
-
-	// The [profile](https://cloud.ibm.com/docs/vpc?topic=vpc-block-storage-profiles) to use for this volume.
-	Profile VolumeProfileIdentityIntf `json:"profile" validate:"required"`
-
-	// The [user tags](https://cloud.ibm.com/apidocs/tagging#types-of-tags) associated with this volume.
-	UserTags []string `json:"user_tags,omitempty"`
-
-	// The capacity to use for the volume (in gigabytes). Must be at least the snapshot's
-	// `minimum_capacity`. The maximum value may increase in the future.
-	//
-	// If unspecified, the capacity will be the source snapshot's `minimum_capacity`.
-	Capacity *int64 `json:"capacity,omitempty"`
-
-	// The root key to use to wrap the data encryption key for the volume.
-	//
-	// If unspecified, the `encryption` type for the volume will be `provider_managed`.
-	EncryptionKey EncryptionKeyIdentityIntf `json:"encryption_key,omitempty"`
-
-	// The snapshot from which to clone the volume.
-	SourceSnapshot SnapshotIdentityIntf `json:"source_snapshot" validate:"required"`
-}
-
-// NewVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot : Instantiate VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot (Generic Model Constructor)
-func (*VpcV1) NewVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot(profile VolumeProfileIdentityIntf, sourceSnapshot SnapshotIdentityIntf) (_model *VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot, err error) {
-	_model = &VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot{
-		Profile:        profile,
-		SourceSnapshot: sourceSnapshot,
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot) isaVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-func (*VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot) isaVolumeAttachmentVolumePrototypeInstanceContext() bool {
-	return true
-}
-
-// UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot unmarshals an instance of VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot from the specified map of raw messages.
-func UnmarshalVolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumePrototypeInstanceContextVolumeBySourceSnapshot)
-	err = core.UnmarshalPrimitive(m, "iops", &obj.Iops)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalVolumeProfileIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "user_tags", &obj.UserTags)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "capacity", &obj.Capacity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "encryption_key", &obj.EncryptionKey, UnmarshalEncryptionKeyIdentity)
-	if err != nil {
-		return
-	}
-	err = core.UnmarshalModel(m, "source_snapshot", &obj.SourceSnapshot, UnmarshalSnapshotIdentity)
-	if err != nil {
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
 // InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup : InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup struct
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByGroup struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -84310,7 +83970,7 @@ func UnmarshalInstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronS
 // InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager : InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager struct
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpec
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronSpecByManager struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -84364,7 +84024,7 @@ func UnmarshalInstanceGroupManagerActionPrototypeScheduledActionPrototypeByCronS
 // InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup : InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup struct
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByGroup struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 
@@ -84417,7 +84077,7 @@ func UnmarshalInstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt
 // InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager : InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager struct
 // This model "extends" InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAt
 type InstanceGroupManagerActionPrototypeScheduledActionPrototypeByRunAtByManager struct {
-	// The user-defined name for this instance group manager action. Names must be unique within the instance group
+	// The name for this instance group manager action. The name must not be used by another action for the instance group
 	// manager. If unspecified, the name will be a hyphenated list of randomly-selected words.
 	Name *string `json:"name,omitempty"`
 

--- a/vpcv1/vpc_v1_examples_test.go
+++ b/vpcv1/vpc_v1_examples_test.go
@@ -1,3 +1,4 @@
+//go:build examples
 // +build examples
 
 /**
@@ -1457,13 +1458,13 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 			volumeProfileIdentityModel := &vpcv1.VolumeProfileIdentityByName{
 				Name: &[]string{"5iops-tier"}[0],
 			}
-			volumeAttachmentPrototypeVolumeModel := &vpcv1.VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext{
+			volumeAttachmentPrototypeVolumeModel := &vpcv1.VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext{
 				Name:          &[]string{"my-instance-modified"}[0],
 				Capacity:      &[]int64{100}[0],
 				EncryptionKey: encryptionKeyIdentityModel,
 				Profile:       volumeProfileIdentityModel,
 			}
-			volumeAttachmentPrototypeModel := &vpcv1.VolumeAttachmentPrototypeInstanceContext{
+			volumeAttachmentPrototypeModel := &vpcv1.VolumeAttachmentPrototype{
 				Volume: volumeAttachmentPrototypeVolumeModel,
 			}
 			vpcIDentityModel := &vpcv1.VPCIdentityByID{
@@ -1486,7 +1487,7 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 				Keys:                    []vpcv1.KeyIdentityIntf{keyIDentityModel},
 				Name:                    &[]string{"my-instance-modified"}[0],
 				Profile:                 instanceProfileIdentityModel,
-				VolumeAttachments:       []vpcv1.VolumeAttachmentPrototypeInstanceContext{*volumeAttachmentPrototypeModel},
+				VolumeAttachments:       []vpcv1.VolumeAttachmentPrototype{*volumeAttachmentPrototypeModel},
 				VPC:                     vpcIDentityModel,
 				Image:                   imageIDentityModel,
 				PrimaryNetworkInterface: networkInterfacePrototypeModel,
@@ -3320,12 +3321,11 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 
 			options := &vpcv1.CreateIkePolicyOptions{}
 			options.SetName(name)
-			options.SetAuthenticationAlgorithm("md5")
-			options.SetDhGroup(2)
+			options.SetAuthenticationAlgorithm("sha512")
+			options.SetDhGroup(14)
 			options.SetEncryptionAlgorithm("aes128")
 			options.SetIkeVersion(1)
 			ikePolicy, response, err := vpcService.CreateIkePolicy(options)
-
 			// end-create_ike_policy
 			if err != nil {
 				panic(err)
@@ -3361,14 +3361,13 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 			}
 			ikePolicyPatchModel := &vpcv1.IkePolicyPatch{}
 			ikePolicyPatchModel.Name = &name
-			ikePolicyPatchModel.DhGroup = &[]int64{5}[0]
+			ikePolicyPatchModel.DhGroup = &[]int64{17}[0]
 			ikePolicyPatch, asPatchErr := ikePolicyPatchModel.AsPatch()
 			if asPatchErr != nil {
 				panic(asPatchErr)
 			}
 			options.IkePolicyPatch = ikePolicyPatch
 			ikePolicy, response, err := vpcService.UpdateIkePolicy(options)
-
 			// end-update_ike_policy
 			if err != nil {
 				panic(err)
@@ -3419,7 +3418,7 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 
 			options := &vpcv1.CreateIpsecPolicyOptions{}
 			options.SetName(name)
-			options.SetAuthenticationAlgorithm("md5")
+			options.SetAuthenticationAlgorithm("sha512")
 			options.SetEncryptionAlgorithm("aes128")
 			options.SetPfs("disabled")
 			ipsecPolicy, response, err := vpcService.CreateIpsecPolicy(options)

--- a/vpcv1/vpc_v1_integration_utils_test.go
+++ b/vpcv1/vpc_v1_integration_utils_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 /**
@@ -899,12 +900,12 @@ func CreateInstance(vpcService *vpcv1.VpcV1, name, profileName, imageID, zoneNam
 	volumeProfileIdentityModel := new(vpcv1.VolumeProfileIdentityByName)
 	volumeProfileIdentityModel.Name = core.StringPtr("general-purpose")
 
-	volume := new(vpcv1.VolumeAttachmentVolumePrototypeInstanceContextVolumePrototypeInstanceContext)
+	volume := new(vpcv1.VolumeAttachmentPrototypeVolumeVolumePrototypeInstanceContext)
 	volume.Capacity = core.Int64Ptr(int64(100))
 	volume.Name = core.StringPtr("my-volume")
 	volume.Profile = volumeProfileIdentityModel
 
-	volumeAttachmentPrototypeModel := new(vpcv1.VolumeAttachmentPrototypeInstanceContext)
+	volumeAttachmentPrototypeModel := new(vpcv1.VolumeAttachmentPrototype)
 	volumeAttachmentPrototypeModel.DeleteVolumeOnInstanceDelete = core.BoolPtr(true)
 	volumeAttachmentPrototypeModel.Name = core.StringPtr("my-volume-attachment")
 	volumeAttachmentPrototypeModel.Volume = volume
@@ -915,7 +916,7 @@ func CreateInstance(vpcService *vpcv1.VpcV1, name, profileName, imageID, zoneNam
 		Name:                    &name,
 		NetworkInterfaces:       []vpcv1.NetworkInterfacePrototype{},
 		Profile:                 &vpcv1.InstanceProfileIdentity{Name: &profileName},
-		VolumeAttachments:       []vpcv1.VolumeAttachmentPrototypeInstanceContext{*volumeAttachmentPrototypeModel},
+		VolumeAttachments:       []vpcv1.VolumeAttachmentPrototype{*volumeAttachmentPrototypeModel},
 		VPC:                     &vpcv1.VPCIdentity{ID: &vpcID},
 		Image:                   &vpcv1.ImageIdentity{ID: &imageID},
 		PrimaryNetworkInterface: &vpcv1.NetworkInterfacePrototype{Subnet: &vpcv1.SubnetIdentity{ID: &subnetID}},
@@ -3372,7 +3373,7 @@ func UpdateSnapshot(vpcService *vpcv1.VpcV1, userTags []string, snapshotId, name
 	return
 }
 
-//Placement Groups
+// Placement Groups
 func ListPlacementGroups(vpcService *vpcv1.VpcV1) (placementGroupCollection *vpcv1.PlacementGroupCollection, response *core.DetailedResponse, err error) {
 	listPlacementGroupsOptions := &vpcv1.ListPlacementGroupsOptions{}
 


### PR DESCRIPTION

```
Ran 2179 of 2179 Specs in 75.484 seconds
SUCCESS! -- 2179 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestVpcV1 (76.22s)
PASS
ok      github.com/IBM/vpc-go-sdk/vpcv1 77.323s
```


## NEW FEATURES 

- None

## BREAKING CHANGES 

- `VolumeAttachmentPrototypeInstanceContext` is changed to `VolumeAttachmentPrototype`
- `HealthReasons` and `HealthState` in `Volume` struct 

## CHANGES 

- Addition of warn logs for deprecated features

## BUG FIXES

- None
