### PR TITLE
feat(2023-05-02): updated the sdk as per the api spec released on 2023-05-02

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/IBM/vpc-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud VPC Go SDK Version 0.36.0
+# IBM Cloud VPC Go SDK Version 0.37.0
 Go client library to interact with the various [IBM Cloud VPC Services APIs](https://cloud.ibm.com/apidocs?category=vpc).
 
 **Note:** Given the current version of all VPC SDKs across supported languages and the current VPC API specification, we retracted the vpc-go-sdk version 1.x to version v0.6.0, which had the same features as v1.0.1.
-Consider using v0.36.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
+Consider using v0.37.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
 
 This SDK uses [Semantic Versioning](https://semver.org), and as such there may be backward-incompatible changes for any new `0.y.z` version.
 ## Table of Contents
@@ -64,7 +64,7 @@ Use this command to download and install the VPC Go SDK service to allow your Go
 use it:
 
 ```
-go get github.com/IBM/vpc-go-sdk@v0.36.0
+go get github.com/IBM/vpc-go-sdk@v0.37.0
 ```
 
 
@@ -90,7 +90,7 @@ to your `Gopkg.toml` file.  Here is an example:
 ```
 [[constraint]]
   name = "github.com/IBM/vpc-go-sdk/"
-  version = "0.36.0"
+  version = "0.37.0"
 ```
 
 Then run `dep ensure`.

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.36.0"
+const Version = "0.37.0"

--- a/vpcv1/vpc_v1_examples_test.go
+++ b/vpcv1/vpc_v1_examples_test.go
@@ -42,6 +42,7 @@ var (
 	subnetID                          string
 	keyID                             string
 	imageID                           string
+	imageExportJobID                  string
 	instanceID                        string
 	addressPrefixID                   string
 	routingTableID                    string
@@ -722,8 +723,7 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 				Name: &[]string{"my-network-acl"}[0],
 				VPC:  vpcIDentityModel,
 			}
-			createNetworkACLOptions := vpcService.NewCreateNetworkACLOptions()
-			createNetworkACLOptions.SetNetworkACLPrototype(networkACLPrototypeModel)
+			createNetworkACLOptions := vpcService.NewCreateNetworkACLOptions(networkACLPrototypeModel)
 			networkACL, _, _ := vpcService.CreateNetworkACL(createNetworkACLOptions)
 			Expect(networkACL).ToNot(BeNil())
 			networkACLID := networkACL.ID
@@ -1088,6 +1088,100 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 			Expect(image).ToNot(BeNil())
 
 		})
+		It(`ListImageExportJobs request example`, func() {
+			fmt.Println("\nListImageExportJobs() result:")
+			// begin-list_image_export_jobs
+
+			listImageExportJobsOptions := vpcService.NewListImageExportJobsOptions(
+				imageID,
+			)
+
+			imageExportJobUnpaginatedCollection, response, err := vpcService.ListImageExportJobs(listImageExportJobsOptions)
+			if err != nil {
+				panic(err)
+			}
+
+			// end-list_image_export_jobs
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(imageExportJobUnpaginatedCollection).ToNot(BeNil())
+		})
+		It(`CreateImageExportJob request example`, func() {
+			fmt.Println("\nCreateImageExportJob() result:")
+			name := getName("image-export")
+			// begin-create_image_export_job
+
+			cloudObjectStorageBucketIdentityModel := &vpcv1.CloudObjectStorageBucketIdentityCloudObjectStorageBucketIdentityByName{
+				Name: core.StringPtr("bucket-27200-lwx4cfvcue"),
+			}
+
+			createImageExportJobOptions := vpcService.NewCreateImageExportJobOptions(
+				imageID,
+				cloudObjectStorageBucketIdentityModel,
+			)
+			createImageExportJobOptions.SetName(name)
+
+			imageExportJob, response, err := vpcService.CreateImageExportJob(createImageExportJobOptions)
+			if err != nil {
+				panic(err)
+			}
+
+			// end-create_image_export_job
+			imageExportJobID = *imageExportJob.ID
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
+			Expect(imageExportJob).ToNot(BeNil())
+		})
+		It(`GetImageExportJob request example`, func() {
+			fmt.Println("\nGetImageExportJob() result:")
+			// begin-get_image_export_job
+
+			getImageExportJobOptions := vpcService.NewGetImageExportJobOptions(
+				imageID,
+				imageExportJobID,
+			)
+
+			imageExportJob, response, err := vpcService.GetImageExportJob(getImageExportJobOptions)
+			if err != nil {
+				panic(err)
+			}
+
+			// end-get_image_export_job
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(imageExportJob).ToNot(BeNil())
+		})
+		It(`UpdateImageExportJob request example`, func() {
+			fmt.Println("\nUpdateImageExportJob() result:")
+			name := getName("image-export-updated")
+			// begin-update_image_export_job
+
+			imageExportJobPatchModel := &vpcv1.ImageExportJobPatch{}
+			imageExportJobPatchModel.Name = &name
+			imageExportJobPatchModelAsPatch, asPatchErr := imageExportJobPatchModel.AsPatch()
+			Expect(asPatchErr).To(BeNil())
+
+			updateImageExportJobOptions := vpcService.NewUpdateImageExportJobOptions(
+				imageID,
+				imageExportJobID,
+				imageExportJobPatchModelAsPatch,
+			)
+
+			imageExportJob, response, err := vpcService.UpdateImageExportJob(updateImageExportJobOptions)
+			if err != nil {
+				panic(err)
+			}
+
+			// end-update_image_export_job
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(imageExportJob).ToNot(BeNil())
+		})
+
 		It(`ListOperatingSystems request example`, func() {
 			fmt.Println("\nListOperatingSystems() result:")
 			// begin-list_operating_systems
@@ -4715,11 +4809,9 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 			fmt.Println("\nCreateBackupPolicy() result:")
 			// begin-create_backup_policy
 
-			createBackupPolicyOptions := vpcService.NewCreateBackupPolicyOptions()
 			userTags := []string{"tag1", "tag2"}
+			createBackupPolicyOptions := vpcService.NewCreateBackupPolicyOptions(userTags)
 			createBackupPolicyOptions.SetName("my-backup-policy")
-			createBackupPolicyOptions.SetMatchUserTags(userTags)
-
 			backupPolicy, response, err := vpcService.CreateBackupPolicy(createBackupPolicyOptions)
 			if err != nil {
 				panic(err)
@@ -6611,6 +6703,29 @@ var _ = Describe(`VpcV1 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(204))
 
 		})
+
+		It(`DeleteImageExportJob request example`, func() {
+			// begin-delete_image_export_job
+
+			deleteImageExportJobOptions := vpcService.NewDeleteImageExportJobOptions(
+				imageID,
+				imageExportJobID,
+			)
+
+			response, err := vpcService.DeleteImageExportJob(deleteImageExportJobOptions)
+			if err != nil {
+				panic(err)
+			}
+			if response.StatusCode != 202 {
+				fmt.Printf("\nUnexpected response status code received from DeleteImageExportJob(): %d\n", response.StatusCode)
+			}
+
+			// end-delete_image_export_job
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
+		})
+
 		It(`DeleteKey request example`, func() {
 			// begin - delete_key
 


### PR DESCRIPTION
```
Ran 2257 of 2257 Specs in 79.114 seconds
SUCCESS! -- 2257 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestVpcV1 (80.09s)
PASS
ok      github.ibm.com/ibmcloud/vpc-go-sdk/vpcv1        81.311s
```

## NEW FEATURES 

-  Support for Image export jobs


## BREAKING CHANGES 

- None

## CHANGES 

- None

## BUG FIXES

- None



Signed-off-by: Ujjwal Kumar <Ujjwal.Kumar1@ibm.com>