### PR TITLE
feat(spec): updated the sdk as per the api spec released on 2023-12-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/IBM/vpc-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud VPC Go SDK Version 0.45.0
+# IBM Cloud VPC Go SDK Version 0.46.0
 Go client library to interact with the various [IBM Cloud VPC Services APIs](https://cloud.ibm.com/apidocs?category=vpc).
 
 **Note:** Given the current version of all VPC SDKs across supported languages and the current VPC API specification, we retracted the vpc-go-sdk version 1.x to version v0.6.0, which had the same features as v1.0.1.
-Consider using v0.45.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
+Consider using v0.46.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
 
 This SDK uses [Semantic Versioning](https://semver.org), and as such there may be backward-incompatible changes for any new `0.y.z` version.
 ## Table of Contents
@@ -64,7 +64,7 @@ Use this command to download and install the VPC Go SDK service to allow your Go
 use it:
 
 ```
-go get github.com/IBM/vpc-go-sdk@v0.45.0
+go get github.com/IBM/vpc-go-sdk@v0.46.0
 ```
 
 
@@ -90,7 +90,7 @@ to your `Gopkg.toml` file.  Here is an example:
 ```
 [[constraint]]
   name = "github.com/IBM/vpc-go-sdk/"
-  version = "0.45.0"
+  version = "0.46.0"
 ```
 
 Then run `dep ensure`.

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.45.0"
+const Version = "0.46.0"


### PR DESCRIPTION


## NEW FEATURES 
- Support for LatestSync in `Share`
- Support for Remote in `ShareReference`
- Introduction of `ShareLatestSync` and `ShareRemote`

## BREAKING CHANGES 

- None

## CHANGES 

- api version `2023-12-12`


## BUG FIXES

- None

```
Ran 2486 of 2486 Specs in 84.993 seconds
SUCCESS! -- 2486 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestVpcV1 (85.85s)
PASS
ok      github.ibm.com/ibmcloud/vpc-go-sdk/vpcv1        87.038s
```