### PR TITLE
fix: fixed the version in the component info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/IBM/vpc-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud VPC Go SDK Version 0.82.0
+# IBM Cloud VPC Go SDK Version 0.82.1
 Go client library to interact with the various [IBM Cloud VPC Services APIs](https://cloud.ibm.com/apidocs?category=vpc).
 
 **Note:** Given the current version of all VPC SDKs across supported languages and the current VPC API specification, we retracted the vpc-go-sdk version 1.x to version v0.6.0, which had the same features as v1.0.1.
-Consider using v0.82.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
+Consider using v0.82.1 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
 
 This SDK uses [Semantic Versioning](https://semver.org), and as such there may be backward-incompatible changes for any new `0.y.z` version.
 ## Table of Contents
@@ -64,7 +64,7 @@ Use this command to download and install the VPC Go SDK service to allow your Go
 use it:
 
 ```
-go get github.com/IBM/vpc-go-sdk@v0.82.0
+go get github.com/IBM/vpc-go-sdk@v0.82.1
 ```
 
 
@@ -90,7 +90,7 @@ to your `Gopkg.toml` file.  Here is an example:
 ```
 [[constraint]]
   name = "github.com/IBM/vpc-go-sdk/"
-  version = "0.82.0"
+  version = "0.82.1"
 ```
 
 Then run `dep ensure`.

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.82.0"
+const Version = "0.82.1"

--- a/vpcv1/vpcv1_service_component_info_test.go
+++ b/vpcv1/vpcv1_service_component_info_test.go
@@ -1,0 +1,51 @@
+/**
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vpcv1
+
+import (
+	"regexp"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getServiceComponentInfo function", func() {
+	It("Should return ProblemComponent with DefaultServiceName and date in YYYY-MM-DD format", func() {
+		// Call the function directly since we're in the same package
+		component := getServiceComponentInfo()
+
+		// Verify the component is not nil
+		Expect(component).ToNot(BeNil())
+
+		// Verify the component name matches DefaultServiceName
+		Expect(component.Name).To(Equal(DefaultServiceName),
+			"Component Name should be DefaultServiceName (vpc)")
+
+		// Verify the version is in YYYY-MM-DD format
+		datePattern := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+		Expect(datePattern.MatchString(component.Version)).To(BeTrue(),
+			"Version should be in YYYY-MM-DD format, got: %s", component.Version)
+	})
+
+	It("Should return the expected ProblemComponent structure", func() {
+		component := getServiceComponentInfo()
+
+		// Verify it's a valid ProblemComponent pointer
+		Expect(component).To(BeAssignableToTypeOf(&core.ProblemComponent{}))
+	})
+})


### PR DESCRIPTION
```
Ran 4034 of 4034 Specs in 110.615 seconds
SUCCESS! -- 4034 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestVpcV1 (111.58s)
PASS
ok      github.com/IBM/vpc-go-sdk/vpcv1 112.371s
```