### PR TITLE
fix(spec): Support for threads per core in instance template

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/IBM/vpc-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud VPC Go SDK Version 0.87.0
+# IBM Cloud VPC Go SDK Version 0.87.1
 Go client library to interact with the various [IBM Cloud VPC Services APIs](https://cloud.ibm.com/apidocs?category=vpc).
 
 **Note:** Given the current version of all VPC SDKs across supported languages and the current VPC API specification, we retracted the vpc-go-sdk version 1.x to version v0.6.0, which had the same features as v1.0.1.
-Consider using v0.87.0 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
+Consider using v0.87.1 from now on. Refrain from using commands like `go get -u ..` and `go get ..@latest` on go 1.14 and lower as you will not get the latest release.
 
 This SDK uses [Semantic Versioning](https://semver.org), and as such there may be backward-incompatible changes for any new `0.y.z` version.
 ## Table of Contents
@@ -64,7 +64,7 @@ Use this command to download and install the VPC Go SDK service to allow your Go
 use it:
 
 ```
-go get github.com/IBM/vpc-go-sdk@v0.87.0
+go get github.com/IBM/vpc-go-sdk@v0.87.1
 ```
 
 
@@ -90,7 +90,7 @@ to your `Gopkg.toml` file.  Here is an example:
 ```
 [[constraint]]
   name = "github.com/IBM/vpc-go-sdk/"
-  version = "0.87.0"
+  version = "0.87.1"
 ```
 
 Then run `dep ensure`.

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.87.0"
+const Version = "0.87.1"

--- a/vpcv1/vpc_v1.go
+++ b/vpcv1/vpc_v1.go
@@ -47,7 +47,7 @@ type VpcV1 struct {
 	Generation *int64
 
 	// The API version, in format `YYYY-MM-DD`. For the API behavior documented here, specify any date between `2026-04-07`
-	// and `2026-06-24`.
+	// and `2026-07-08`.
 	Version *string
 }
 
@@ -68,7 +68,7 @@ type VpcV1Options struct {
 	Generation *int64
 
 	// The API version, in format `YYYY-MM-DD`. For the API behavior documented here, specify any date between `2026-04-07`
-	// and `2026-06-24`.
+	// and `2026-07-08`.
 	Version *string
 }
 
@@ -69913,6 +69913,7 @@ func UnmarshalInstanceInitializationPassword(m map[string]json.RawMessage, resul
 type InstanceLifecycleReason struct {
 	// A reason code for this lifecycle state:
 	// - `failed_licensing`: Allocation of one or more software license(s) has failed. Delete
+	//   the instance and provision it again. If the problem persists, contact IBM Support.
 	// - `failed_registration`: The instance's registration to Resource Controller has
 	//   failed. Delete the instance and provision it again. If the problem persists,
 	//   contact IBM Support.
@@ -69936,6 +69937,7 @@ type InstanceLifecycleReason struct {
 // Constants associated with the InstanceLifecycleReason.Code property.
 // A reason code for this lifecycle state:
 //   - `failed_licensing`: Allocation of one or more software license(s) has failed. Delete
+//     the instance and provision it again. If the problem persists, contact IBM Support.
 //   - `failed_registration`: The instance's registration to Resource Controller has
 //     failed. Delete the instance and provision it again. If the problem persists,
 //     contact IBM Support.
@@ -74634,6 +74636,11 @@ func UnmarshalInstanceTemplate(m map[string]json.RawMessage, result interface{})
 		err = core.UnmarshalModel(m, "resource_group", &obj.ResourceGroup, UnmarshalResourceGroupReference)
 		if err != nil {
 			err = core.SDKErrorf(err, "", "resource_group-error", common.GetComponentInfo())
+			return
+		}
+		err = core.UnmarshalPrimitive(m, "threads_per_core", &obj.ThreadsPerCore)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "threads_per_core-error", common.GetComponentInfo())
 			return
 		}
 		err = core.UnmarshalPrimitive(m, "total_volume_bandwidth", &obj.TotalVolumeBandwidth)


### PR DESCRIPTION
```
Ran 4074 of 4074 Specs in 110.867 seconds
SUCCESS! -- 4074 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestVpcV1 (111.80s)
PASS
ok      github.com/IBM/vpc-go-sdk/vpcv1 112.736s
```